### PR TITLE
feat(order-service): add REST controller with CRUD and query endpoints

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,87 @@
+# MicroCommerce - Contexto para Claude Code
+
+## Descripcion
+Arquitectura de microservicios e-commerce en Java 17 con Spring Boot. Proyecto portfolio de Cristian Soncco para Technologies Partner.
+
+## Reglas de trabajo
+- Logs y mensajes de error en español
+- Documentacion bilingue (ES/EN)
+- Sin emoticonos en documentacion
+- Conventional Commits obligatorio
+- Coverage minimo 80% en tests
+- Cada commit debe compilar sin errores
+
+## Stack
+- Java 17, Spring Boot 3
+- PostgreSQL (Product Service, User Service)
+- MongoDB (Order Service)
+- Redis (caching, Cache-Aside pattern)
+- RabbitMQ (eventos)
+- Eureka Server (discovery)
+- Config Server (configuracion centralizada)
+- API Gateway (punto de entrada unico)
+- Docker Compose para desarrollo
+- JUnit 5, Mockito, TestContainers para tests
+- Swagger para documentacion API
+
+## Estrategia Git
+- Rama principal de desarrollo: develop
+- Ramas de feature: feat/nombre-feature
+- Squash merge a develop, luego a main
+- Abrir PR a develop al terminar cada commit
+
+## Checklist de commits
+
+### Fase 1: Infraestructura [COMPLETADO]
+- [x] COMMIT 1: Estructura base del proyecto
+- [x] COMMIT 2: Eureka Server
+- [x] COMMIT 3: Config Server
+- [x] COMMIT 4: API Gateway
+
+### Fase 2: Product Service [COMPLETADO]
+- [x] COMMIT 5: Entidades y Repository
+- [x] COMMIT 6: Service Layer con Redis
+- [x] COMMIT 7: REST Controller
+- [x] COMMIT 8: Tests (Unit + Integration)
+
+### Fase 3: Order Service [EN PROGRESO]
+- [x] COMMIT 9: Entidades y Repository (MongoDB)
+- [x] COMMIT 10: Service Layer
+- [x] COMMIT 11: REST Controller
+- [ ] COMMIT 12: Tests
+
+### Fase 4: User Service [PENDIENTE]
+- [ ] COMMIT 13: Entidades y Repository
+- [ ] COMMIT 14: Service Layer con JWT
+- [ ] COMMIT 15: REST Controller
+- [ ] COMMIT 16: Tests
+
+### Fase 5: Payment Service [PENDIENTE]
+- [ ] COMMIT 17: Integracion con API externa
+- [ ] COMMIT 18: Service Layer
+- [ ] COMMIT 19: REST Controller
+- [ ] COMMIT 20: Tests
+
+### Fase 6: Features Avanzadas [PENDIENTE]
+- [ ] COMMIT 21: Event-Driven con RabbitMQ
+- [ ] COMMIT 22: Logging centralizado (ELK)
+- [ ] COMMIT 23: Monitoring (Prometheus + Grafana)
+- [ ] COMMIT 24: API Versioning
+
+### Fase 7: Kubernetes y DevOps [PENDIENTE]
+- [ ] COMMIT 25: Kubernetes manifests
+- [ ] COMMIT 26: Helm charts
+- [ ] COMMIT 27: CI/CD Pipeline (GitHub Actions)
+
+## Estado actual
+- Ultimo commit completado: COMMIT 11 - REST Controller Order Service
+- Rama activa: feat/order-rest-controller
+- Proximo objetivo: COMMIT 12 - Tests Order Service
+
+## Al terminar cada commit
+1. Verificar que compila sin errores
+2. Verificar que los tests pasan
+3. Actualizar este CLAUDE.md marcando el commit como completado
+4. Hacer commit con mensaje segun Conventional Commits
+5. Push a la rama actual
+6. Abrir PR a develop

--- a/order-service/pom.xml
+++ b/order-service/pom.xml
@@ -68,6 +68,13 @@
             <artifactId>mapstruct</artifactId>
         </dependency>
 
+        <!-- Swagger / OpenAPI -->
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.3.0</version>
+        </dependency>
+
         <!-- Actuator -->
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/order-service/src/main/java/com/microcommerce/order/controller/OrderController.java
+++ b/order-service/src/main/java/com/microcommerce/order/controller/OrderController.java
@@ -1,0 +1,433 @@
+package com.microcommerce.order.controller;
+
+import com.microcommerce.order.dto.OrderDTO;
+import com.microcommerce.order.dto.response.ApiResponse;
+import com.microcommerce.order.dto.response.OrderResponse;
+import com.microcommerce.order.entity.Order;
+import com.microcommerce.order.entity.Order.OrderStatus;
+import com.microcommerce.order.mapper.OrderMapper;
+import com.microcommerce.order.service.OrderService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * REST Controller for Order operations
+ * Controlador REST para operaciones de Pedidos
+ *
+ * Exposes CRUD endpoints and query operations for order management.
+ * Expone endpoints CRUD y operaciones de consulta para gestion de pedidos.
+ */
+@RestController
+@RequestMapping("/api/orders")
+@RequiredArgsConstructor
+@Slf4j
+@Tag(name = "Orders", description = "API de gestion de pedidos | Order management API")
+public class OrderController {
+
+    private final OrderService orderService;
+    private final OrderMapper orderMapper;
+
+    /**
+     * Create a new order
+     * Crear un nuevo pedido
+     */
+    @PostMapping
+    @Operation(
+        summary = "Crear pedido | Create order",
+        description = "Crea un nuevo pedido con los items proporcionados | Creates a new order with the provided items"
+    )
+    @ApiResponses(value = {
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "201",
+            description = "Pedido creado exitosamente | Order created successfully"
+        ),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "400",
+            description = "Datos de entrada invalidos | Invalid input data"
+        )
+    })
+    public ResponseEntity<ApiResponse<OrderResponse>> createOrder(
+            @Valid @RequestBody OrderDTO orderDTO) {
+
+        log.info("Solicitud para crear pedido del usuario: {}", orderDTO.getUserId());
+
+        Order order = orderService.createOrder(orderDTO);
+        OrderResponse response = orderMapper.toResponse(order);
+
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(ApiResponse.success("Pedido creado exitosamente", response));
+    }
+
+    /**
+     * Get order by ID
+     * Obtener pedido por ID
+     */
+    @GetMapping("/{id}")
+    @Operation(
+        summary = "Obtener pedido por ID | Get order by ID",
+        description = "Obtiene un pedido por su ID | Gets an order by its ID"
+    )
+    @ApiResponses(value = {
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "200",
+            description = "Pedido encontrado | Order found"
+        ),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "404",
+            description = "Pedido no encontrado | Order not found"
+        )
+    })
+    public ResponseEntity<ApiResponse<OrderResponse>> getOrderById(
+            @Parameter(description = "ID del pedido | Order ID")
+            @PathVariable String id) {
+
+        log.info("Solicitud para obtener pedido con ID: {}", id);
+
+        Order order = orderService.getOrderById(id);
+        OrderResponse response = orderMapper.toResponse(order);
+
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * Get all orders
+     * Obtener todos los pedidos
+     */
+    @GetMapping
+    @Operation(
+        summary = "Listar todos los pedidos | List all orders",
+        description = "Obtiene la lista de todos los pedidos | Gets the list of all orders"
+    )
+    public ResponseEntity<ApiResponse<List<OrderResponse>>> getAllOrders() {
+
+        log.info("Solicitud para obtener todos los pedidos");
+
+        List<Order> orders = orderService.getAllOrders();
+        List<OrderResponse> responses = orderMapper.toResponseList(orders);
+
+        return ResponseEntity.ok(ApiResponse.success(responses));
+    }
+
+    /**
+     * Get orders by user ID
+     * Obtener pedidos por ID de usuario
+     */
+    @GetMapping("/user/{userId}")
+    @Operation(
+        summary = "Obtener pedidos por usuario | Get orders by user",
+        description = "Obtiene todos los pedidos de un usuario | Gets all orders for a user"
+    )
+    public ResponseEntity<ApiResponse<List<OrderResponse>>> getOrdersByUserId(
+            @Parameter(description = "ID del usuario | User ID")
+            @PathVariable Long userId) {
+
+        log.info("Solicitud para obtener pedidos del usuario: {}", userId);
+
+        List<Order> orders = orderService.getOrdersByUserId(userId);
+        List<OrderResponse> responses = orderMapper.toResponseList(orders);
+
+        return ResponseEntity.ok(ApiResponse.success(responses));
+    }
+
+    /**
+     * Get orders by user ID and status
+     * Obtener pedidos por ID de usuario y estado
+     */
+    @GetMapping("/user/{userId}/status/{status}")
+    @Operation(
+        summary = "Obtener pedidos por usuario y estado | Get orders by user and status",
+        description = "Obtiene pedidos de un usuario filtrados por estado | Gets orders for a user filtered by status"
+    )
+    public ResponseEntity<ApiResponse<List<OrderResponse>>> getOrdersByUserIdAndStatus(
+            @Parameter(description = "ID del usuario | User ID")
+            @PathVariable Long userId,
+            @Parameter(description = "Estado del pedido | Order status")
+            @PathVariable OrderStatus status) {
+
+        log.info("Solicitud para obtener pedidos del usuario {} con estado {}", userId, status);
+
+        List<Order> orders = orderService.getOrdersByUserIdAndStatus(userId, status);
+        List<OrderResponse> responses = orderMapper.toResponseList(orders);
+
+        return ResponseEntity.ok(ApiResponse.success(responses));
+    }
+
+    /**
+     * Get orders by status
+     * Obtener pedidos por estado
+     */
+    @GetMapping("/status/{status}")
+    @Operation(
+        summary = "Obtener pedidos por estado | Get orders by status",
+        description = "Obtiene todos los pedidos con un estado especifico | Gets all orders with a specific status"
+    )
+    public ResponseEntity<ApiResponse<List<OrderResponse>>> getOrdersByStatus(
+            @Parameter(description = "Estado del pedido | Order status")
+            @PathVariable OrderStatus status) {
+
+        log.info("Solicitud para obtener pedidos con estado: {}", status);
+
+        List<Order> orders = orderService.getOrdersByStatus(status);
+        List<OrderResponse> responses = orderMapper.toResponseList(orders);
+
+        return ResponseEntity.ok(ApiResponse.success(responses));
+    }
+
+    /**
+     * Get recent orders by user ID
+     * Obtener pedidos recientes por ID de usuario
+     */
+    @GetMapping("/user/{userId}/recent")
+    @Operation(
+        summary = "Obtener pedidos recientes del usuario | Get recent user orders",
+        description = "Obtiene los pedidos mas recientes de un usuario | Gets the most recent orders for a user"
+    )
+    public ResponseEntity<ApiResponse<List<OrderResponse>>> getRecentOrdersByUserId(
+            @Parameter(description = "ID del usuario | User ID")
+            @PathVariable Long userId) {
+
+        log.info("Solicitud para obtener pedidos recientes del usuario: {}", userId);
+
+        List<Order> orders = orderService.getRecentOrdersByUserId(userId);
+        List<OrderResponse> responses = orderMapper.toResponseList(orders);
+
+        return ResponseEntity.ok(ApiResponse.success(responses));
+    }
+
+    /**
+     * Get orders by date range
+     * Obtener pedidos por rango de fechas
+     */
+    @GetMapping("/date-range")
+    @Operation(
+        summary = "Obtener pedidos por rango de fechas | Get orders by date range",
+        description = "Obtiene pedidos creados entre dos fechas | Gets orders created between two dates"
+    )
+    public ResponseEntity<ApiResponse<List<OrderResponse>>> getOrdersByDateRange(
+            @Parameter(description = "Fecha de inicio (ISO format) | Start date (ISO format)")
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime startDate,
+            @Parameter(description = "Fecha de fin (ISO format) | End date (ISO format)")
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime endDate) {
+
+        log.info("Solicitud para obtener pedidos entre {} y {}", startDate, endDate);
+
+        List<Order> orders = orderService.getOrdersByDateRange(startDate, endDate);
+        List<OrderResponse> responses = orderMapper.toResponseList(orders);
+
+        return ResponseEntity.ok(ApiResponse.success(responses));
+    }
+
+    /**
+     * Update order
+     * Actualizar pedido
+     */
+    @PutMapping("/{id}")
+    @Operation(
+        summary = "Actualizar pedido | Update order",
+        description = "Actualiza un pedido existente (solo en estado PENDING) | Updates an existing order (only in PENDING status)"
+    )
+    @ApiResponses(value = {
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "200",
+            description = "Pedido actualizado | Order updated"
+        ),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "400",
+            description = "Estado invalido para actualizacion | Invalid status for update"
+        ),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "404",
+            description = "Pedido no encontrado | Order not found"
+        )
+    })
+    public ResponseEntity<ApiResponse<OrderResponse>> updateOrder(
+            @Parameter(description = "ID del pedido | Order ID")
+            @PathVariable String id,
+            @Valid @RequestBody OrderDTO orderDTO) {
+
+        log.info("Solicitud para actualizar pedido con ID: {}", id);
+
+        Order order = orderService.updateOrder(id, orderDTO);
+        OrderResponse response = orderMapper.toResponse(order);
+
+        return ResponseEntity.ok(ApiResponse.success("Pedido actualizado exitosamente", response));
+    }
+
+    /**
+     * Update order status
+     * Actualizar estado del pedido
+     */
+    @PatchMapping("/{id}/status")
+    @Operation(
+        summary = "Actualizar estado del pedido | Update order status",
+        description = "Actualiza el estado de un pedido con validacion de transiciones | Updates order status with transition validation"
+    )
+    @ApiResponses(value = {
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "200",
+            description = "Estado actualizado | Status updated"
+        ),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "400",
+            description = "Transicion de estado invalida | Invalid status transition"
+        ),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "404",
+            description = "Pedido no encontrado | Order not found"
+        )
+    })
+    public ResponseEntity<ApiResponse<OrderResponse>> updateOrderStatus(
+            @Parameter(description = "ID del pedido | Order ID")
+            @PathVariable String id,
+            @Parameter(description = "Nuevo estado | New status")
+            @RequestParam OrderStatus status) {
+
+        log.info("Solicitud para actualizar estado del pedido {} a {}", id, status);
+
+        Order order = orderService.updateOrderStatus(id, status);
+        OrderResponse response = orderMapper.toResponse(order);
+
+        return ResponseEntity.ok(ApiResponse.success("Estado del pedido actualizado exitosamente", response));
+    }
+
+    /**
+     * Cancel order
+     * Cancelar pedido
+     */
+    @PatchMapping("/{id}/cancel")
+    @Operation(
+        summary = "Cancelar pedido | Cancel order",
+        description = "Cancela un pedido si su estado lo permite | Cancels an order if its status allows it"
+    )
+    @ApiResponses(value = {
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "200",
+            description = "Pedido cancelado | Order cancelled"
+        ),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "400",
+            description = "No se puede cancelar el pedido | Cannot cancel the order"
+        ),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "404",
+            description = "Pedido no encontrado | Order not found"
+        )
+    })
+    public ResponseEntity<ApiResponse<OrderResponse>> cancelOrder(
+            @Parameter(description = "ID del pedido | Order ID")
+            @PathVariable String id) {
+
+        log.info("Solicitud para cancelar pedido: {}", id);
+
+        Order order = orderService.cancelOrder(id);
+        OrderResponse response = orderMapper.toResponse(order);
+
+        return ResponseEntity.ok(ApiResponse.success("Pedido cancelado exitosamente", response));
+    }
+
+    /**
+     * Delete order
+     * Eliminar pedido
+     */
+    @DeleteMapping("/{id}")
+    @Operation(
+        summary = "Eliminar pedido | Delete order",
+        description = "Elimina un pedido del sistema | Deletes an order from the system"
+    )
+    @ApiResponses(value = {
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "200",
+            description = "Pedido eliminado | Order deleted"
+        ),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "404",
+            description = "Pedido no encontrado | Order not found"
+        )
+    })
+    public ResponseEntity<ApiResponse<Void>> deleteOrder(
+            @Parameter(description = "ID del pedido | Order ID")
+            @PathVariable String id) {
+
+        log.info("Solicitud para eliminar pedido con ID: {}", id);
+
+        orderService.deleteOrder(id);
+
+        return ResponseEntity.ok(ApiResponse.success("Pedido eliminado exitosamente", null));
+    }
+
+    /**
+     * Count orders by user ID
+     * Contar pedidos por ID de usuario
+     */
+    @GetMapping("/user/{userId}/count")
+    @Operation(
+        summary = "Contar pedidos del usuario | Count user orders",
+        description = "Obtiene el numero total de pedidos de un usuario | Gets the total number of orders for a user"
+    )
+    public ResponseEntity<ApiResponse<Long>> countOrdersByUserId(
+            @Parameter(description = "ID del usuario | User ID")
+            @PathVariable Long userId) {
+
+        log.info("Solicitud para contar pedidos del usuario: {}", userId);
+
+        long count = orderService.countOrdersByUserId(userId);
+
+        return ResponseEntity.ok(ApiResponse.success(count));
+    }
+
+    /**
+     * Count orders by status
+     * Contar pedidos por estado
+     */
+    @GetMapping("/status/{status}/count")
+    @Operation(
+        summary = "Contar pedidos por estado | Count orders by status",
+        description = "Obtiene el numero total de pedidos con un estado especifico | Gets the total number of orders with a specific status"
+    )
+    public ResponseEntity<ApiResponse<Long>> countOrdersByStatus(
+            @Parameter(description = "Estado del pedido | Order status")
+            @PathVariable OrderStatus status) {
+
+        log.info("Solicitud para contar pedidos con estado: {}", status);
+
+        long count = orderService.countOrdersByStatus(status);
+
+        return ResponseEntity.ok(ApiResponse.success(count));
+    }
+
+    /**
+     * Check if user has orders
+     * Verificar si un usuario tiene pedidos
+     */
+    @GetMapping("/user/{userId}/exists")
+    @Operation(
+        summary = "Verificar si el usuario tiene pedidos | Check if user has orders",
+        description = "Verifica si un usuario tiene al menos un pedido | Checks if a user has at least one order"
+    )
+    public ResponseEntity<ApiResponse<Boolean>> userHasOrders(
+            @Parameter(description = "ID del usuario | User ID")
+            @PathVariable Long userId) {
+
+        log.info("Solicitud para verificar si el usuario {} tiene pedidos", userId);
+
+        boolean hasOrders = orderService.userHasOrders(userId);
+        String message = hasOrders
+                ? "El usuario tiene pedidos"
+                : "El usuario no tiene pedidos";
+
+        return ResponseEntity.ok(ApiResponse.success(message, hasOrders));
+    }
+}


### PR DESCRIPTION
## Summary
- Add `OrderController` with full CRUD endpoints for order management (`/api/orders`)
- Expose query endpoints: by user, status, date range, recent orders, counts, and existence checks
- Add status update (`PATCH /{id}/status`) and cancel (`PATCH /{id}/cancel`) endpoints with transition validation
- Add `springdoc-openapi` dependency for Swagger/OpenAPI documentation
- All API descriptions are bilingual (ES/EN)

## Test plan
- [ ] Verify `mvn compile -pl order-service` passes without errors
- [ ] Verify Swagger UI is accessible at `/swagger-ui.html` when service is running
- [ ] Test all CRUD endpoints with valid and invalid payloads
- [ ] Test status transition validation (valid and invalid transitions)
- [ ] Test query endpoints (by user, status, date range)
- [ ] Verify error responses follow the established `ErrorResponse` format