### PR TITLE
test(order-service): add unit and integration tests

### DIFF
--- a/order-service/src/test/java/com/microcommerce/order/controller/OrderControllerTest.java
+++ b/order-service/src/test/java/com/microcommerce/order/controller/OrderControllerTest.java
@@ -1,0 +1,548 @@
+package com.microcommerce.order.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.microcommerce.order.dto.OrderDTO;
+import com.microcommerce.order.dto.OrderItemDTO;
+import com.microcommerce.order.dto.response.OrderResponse;
+import com.microcommerce.order.dto.response.OrderResponse.OrderItemResponse;
+import com.microcommerce.order.entity.Order;
+import com.microcommerce.order.entity.Order.OrderStatus;
+import com.microcommerce.order.entity.OrderItem;
+import com.microcommerce.order.exception.EmptyOrderException;
+import com.microcommerce.order.exception.InvalidOrderStatusException;
+import com.microcommerce.order.exception.OrderNotFoundException;
+import com.microcommerce.order.exception.handler.GlobalExceptionHandler;
+import com.microcommerce.order.mapper.OrderMapper;
+import com.microcommerce.order.service.OrderService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+/**
+ * Controller tests for OrderController with MockMvc
+ * Tests de controlador para OrderController con MockMvc
+ */
+@WebMvcTest(OrderController.class)
+@Import(GlobalExceptionHandler.class)
+@ActiveProfiles("test-nodb")
+@DisplayName("OrderController Tests")
+class OrderControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private OrderService orderService;
+
+    @MockBean
+    private OrderMapper orderMapper;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private Order order;
+    private OrderDTO orderDTO;
+    private OrderResponse orderResponse;
+
+    @BeforeEach
+    void setUp() {
+        OrderItem orderItem = OrderItem.builder()
+                .productId(1L)
+                .productName("Laptop HP")
+                .quantity(2)
+                .unitPrice(new BigDecimal("999.99"))
+                .subtotal(new BigDecimal("1999.98"))
+                .build();
+
+        order = Order.builder()
+                .id("order-001")
+                .userId(1L)
+                .status(OrderStatus.PENDING)
+                .totalAmount(new BigDecimal("1999.98"))
+                .shippingAddress("Av. Principal 123, Lima, Peru")
+                .paymentMethod("CREDIT_CARD")
+                .notes("Test order")
+                .items(List.of(orderItem))
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build();
+
+        OrderItemDTO orderItemDTO = OrderItemDTO.builder()
+                .productId(1L)
+                .productName("Laptop HP")
+                .quantity(2)
+                .unitPrice(new BigDecimal("999.99"))
+                .build();
+
+        orderDTO = OrderDTO.builder()
+                .userId(1L)
+                .shippingAddress("Av. Principal 123, Lima, Peru")
+                .paymentMethod("CREDIT_CARD")
+                .notes("Test order")
+                .items(List.of(orderItemDTO))
+                .build();
+
+        OrderItemResponse itemResponse = OrderItemResponse.builder()
+                .productId(1L)
+                .productName("Laptop HP")
+                .quantity(2)
+                .unitPrice(new BigDecimal("999.99"))
+                .subtotal(new BigDecimal("1999.98"))
+                .build();
+
+        orderResponse = OrderResponse.builder()
+                .id("order-001")
+                .userId(1L)
+                .status(OrderStatus.PENDING)
+                .totalAmount(new BigDecimal("1999.98"))
+                .shippingAddress("Av. Principal 123, Lima, Peru")
+                .paymentMethod("CREDIT_CARD")
+                .notes("Test order")
+                .items(List.of(itemResponse))
+                .itemCount(1)
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build();
+    }
+
+    // --- POST /api/orders ---
+
+    @Test
+    @DisplayName("POST /api/orders - request valido - debe retornar 201")
+    void createOrder_ValidRequest_Returns201() throws Exception {
+        // Given
+        when(orderService.createOrder(any(OrderDTO.class))).thenReturn(order);
+        when(orderMapper.toResponse(any(Order.class))).thenReturn(orderResponse);
+
+        // When & Then
+        mockMvc.perform(post("/api/orders")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(orderDTO)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.message").value("Pedido creado exitosamente"))
+                .andExpect(jsonPath("$.data.id").value("order-001"))
+                .andExpect(jsonPath("$.data.userId").value(1))
+                .andExpect(jsonPath("$.data.status").value("PENDING"));
+
+        verify(orderService).createOrder(any(OrderDTO.class));
+    }
+
+    @Test
+    @DisplayName("POST /api/orders - sin userId - debe retornar 400")
+    void createOrder_MissingUserId_Returns400() throws Exception {
+        // Given
+        orderDTO.setUserId(null);
+
+        // When & Then
+        mockMvc.perform(post("/api/orders")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(orderDTO)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.error").value("Validation Error"));
+
+        verify(orderService, never()).createOrder(any());
+    }
+
+    @Test
+    @DisplayName("POST /api/orders - sin shippingAddress - debe retornar 400")
+    void createOrder_MissingShippingAddress_Returns400() throws Exception {
+        // Given
+        orderDTO.setShippingAddress(null);
+
+        // When & Then
+        mockMvc.perform(post("/api/orders")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(orderDTO)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400));
+
+        verify(orderService, never()).createOrder(any());
+    }
+
+    @Test
+    @DisplayName("POST /api/orders - pedido vacio - debe retornar 400")
+    void createOrder_EmptyOrder_Returns400() throws Exception {
+        // Given
+        when(orderService.createOrder(any(OrderDTO.class)))
+                .thenThrow(new EmptyOrderException());
+
+        // When & Then
+        mockMvc.perform(post("/api/orders")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(orderDTO)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.message").exists());
+    }
+
+    // --- GET /api/orders/{id} ---
+
+    @Test
+    @DisplayName("GET /api/orders/{id} - ID existente - debe retornar 200")
+    void getOrderById_ExistingId_Returns200() throws Exception {
+        // Given
+        when(orderService.getOrderById("order-001")).thenReturn(order);
+        when(orderMapper.toResponse(order)).thenReturn(orderResponse);
+
+        // When & Then
+        mockMvc.perform(get("/api/orders/order-001"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.id").value("order-001"))
+                .andExpect(jsonPath("$.data.userId").value(1));
+
+        verify(orderService).getOrderById("order-001");
+    }
+
+    @Test
+    @DisplayName("GET /api/orders/{id} - ID no existente - debe retornar 404")
+    void getOrderById_NonExistingId_Returns404() throws Exception {
+        // Given
+        when(orderService.getOrderById("nonexistent"))
+                .thenThrow(new OrderNotFoundException("nonexistent"));
+
+        // When & Then
+        mockMvc.perform(get("/api/orders/nonexistent"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.status").value(404))
+                .andExpect(jsonPath("$.message").exists());
+    }
+
+    // --- GET /api/orders ---
+
+    @Test
+    @DisplayName("GET /api/orders - debe retornar lista de pedidos")
+    void getAllOrders_ReturnsOrderList() throws Exception {
+        // Given
+        List<Order> orders = Arrays.asList(order, order);
+        List<OrderResponse> responses = Arrays.asList(orderResponse, orderResponse);
+
+        when(orderService.getAllOrders()).thenReturn(orders);
+        when(orderMapper.toResponseList(orders)).thenReturn(responses);
+
+        // When & Then
+        mockMvc.perform(get("/api/orders"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data", hasSize(2)));
+
+        verify(orderService).getAllOrders();
+    }
+
+    // --- GET /api/orders/user/{userId} ---
+
+    @Test
+    @DisplayName("GET /api/orders/user/{userId} - debe retornar pedidos del usuario")
+    void getOrdersByUserId_ReturnsUserOrders() throws Exception {
+        // Given
+        when(orderService.getOrdersByUserId(1L)).thenReturn(List.of(order));
+        when(orderMapper.toResponseList(anyList())).thenReturn(List.of(orderResponse));
+
+        // When & Then
+        mockMvc.perform(get("/api/orders/user/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data", hasSize(1)));
+
+        verify(orderService).getOrdersByUserId(1L);
+    }
+
+    // --- GET /api/orders/status/{status} ---
+
+    @Test
+    @DisplayName("GET /api/orders/status/{status} - debe retornar pedidos por estado")
+    void getOrdersByStatus_ReturnsOrdersByStatus() throws Exception {
+        // Given
+        when(orderService.getOrdersByStatus(OrderStatus.PENDING)).thenReturn(List.of(order));
+        when(orderMapper.toResponseList(anyList())).thenReturn(List.of(orderResponse));
+
+        // When & Then
+        mockMvc.perform(get("/api/orders/status/PENDING"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isArray());
+
+        verify(orderService).getOrdersByStatus(OrderStatus.PENDING);
+    }
+
+    // --- GET /api/orders/user/{userId}/status/{status} ---
+
+    @Test
+    @DisplayName("GET /api/orders/user/{userId}/status/{status} - debe filtrar por usuario y estado")
+    void getOrdersByUserIdAndStatus_ReturnsFilteredOrders() throws Exception {
+        // Given
+        when(orderService.getOrdersByUserIdAndStatus(1L, OrderStatus.PENDING))
+                .thenReturn(List.of(order));
+        when(orderMapper.toResponseList(anyList())).thenReturn(List.of(orderResponse));
+
+        // When & Then
+        mockMvc.perform(get("/api/orders/user/1/status/PENDING"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isArray());
+
+        verify(orderService).getOrdersByUserIdAndStatus(1L, OrderStatus.PENDING);
+    }
+
+    // --- GET /api/orders/user/{userId}/recent ---
+
+    @Test
+    @DisplayName("GET /api/orders/user/{userId}/recent - debe retornar pedidos recientes")
+    void getRecentOrdersByUserId_ReturnsRecentOrders() throws Exception {
+        // Given
+        when(orderService.getRecentOrdersByUserId(1L)).thenReturn(List.of(order));
+        when(orderMapper.toResponseList(anyList())).thenReturn(List.of(orderResponse));
+
+        // When & Then
+        mockMvc.perform(get("/api/orders/user/1/recent"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isArray());
+
+        verify(orderService).getRecentOrdersByUserId(1L);
+    }
+
+    // --- PUT /api/orders/{id} ---
+
+    @Test
+    @DisplayName("PUT /api/orders/{id} - request valido - debe retornar 200")
+    void updateOrder_ValidRequest_Returns200() throws Exception {
+        // Given
+        when(orderService.updateOrder(eq("order-001"), any(OrderDTO.class))).thenReturn(order);
+        when(orderMapper.toResponse(order)).thenReturn(orderResponse);
+
+        // When & Then
+        mockMvc.perform(put("/api/orders/order-001")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(orderDTO)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.message").value("Pedido actualizado exitosamente"))
+                .andExpect(jsonPath("$.data.id").value("order-001"));
+
+        verify(orderService).updateOrder(eq("order-001"), any(OrderDTO.class));
+    }
+
+    @Test
+    @DisplayName("PUT /api/orders/{id} - ID no existente - debe retornar 404")
+    void updateOrder_NonExistingId_Returns404() throws Exception {
+        // Given
+        when(orderService.updateOrder(eq("nonexistent"), any(OrderDTO.class)))
+                .thenThrow(new OrderNotFoundException("nonexistent"));
+
+        // When & Then
+        mockMvc.perform(put("/api/orders/nonexistent")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(orderDTO)))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("PUT /api/orders/{id} - estado invalido - debe retornar 400")
+    void updateOrder_InvalidStatus_Returns400() throws Exception {
+        // Given
+        when(orderService.updateOrder(eq("order-001"), any(OrderDTO.class)))
+                .thenThrow(new InvalidOrderStatusException(OrderStatus.PAID, OrderStatus.PENDING));
+
+        // When & Then
+        mockMvc.perform(put("/api/orders/order-001")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(orderDTO)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400));
+    }
+
+    // --- PATCH /api/orders/{id}/status ---
+
+    @Test
+    @DisplayName("PATCH /api/orders/{id}/status - transicion valida - debe retornar 200")
+    void updateOrderStatus_ValidTransition_Returns200() throws Exception {
+        // Given
+        order.setStatus(OrderStatus.PAID);
+        orderResponse.setStatus(OrderStatus.PAID);
+        when(orderService.updateOrderStatus("order-001", OrderStatus.PAID)).thenReturn(order);
+        when(orderMapper.toResponse(order)).thenReturn(orderResponse);
+
+        Map<String, String> statusRequest = Map.of("status", "PAID");
+
+        // When & Then
+        mockMvc.perform(patch("/api/orders/order-001/status")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(statusRequest)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.message").value("Estado del pedido actualizado exitosamente"));
+
+        verify(orderService).updateOrderStatus("order-001", OrderStatus.PAID);
+    }
+
+    @Test
+    @DisplayName("PATCH /api/orders/{id}/status - transicion invalida - debe retornar 400")
+    void updateOrderStatus_InvalidTransition_Returns400() throws Exception {
+        // Given
+        when(orderService.updateOrderStatus("order-001", OrderStatus.SHIPPED))
+                .thenThrow(new InvalidOrderStatusException(OrderStatus.PENDING, OrderStatus.SHIPPED));
+
+        Map<String, String> statusRequest = Map.of("status", "SHIPPED");
+
+        // When & Then
+        mockMvc.perform(patch("/api/orders/order-001/status")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(statusRequest)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400));
+    }
+
+    // --- PATCH /api/orders/{id}/cancel ---
+
+    @Test
+    @DisplayName("PATCH /api/orders/{id}/cancel - pedido cancelable - debe retornar 200")
+    void cancelOrder_CancellableOrder_Returns200() throws Exception {
+        // Given
+        order.setStatus(OrderStatus.CANCELLED);
+        orderResponse.setStatus(OrderStatus.CANCELLED);
+        when(orderService.cancelOrder("order-001")).thenReturn(order);
+        when(orderMapper.toResponse(order)).thenReturn(orderResponse);
+
+        // When & Then
+        mockMvc.perform(patch("/api/orders/order-001/cancel"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.message").value("Pedido cancelado exitosamente"));
+
+        verify(orderService).cancelOrder("order-001");
+    }
+
+    @Test
+    @DisplayName("PATCH /api/orders/{id}/cancel - pedido no cancelable - debe retornar 400")
+    void cancelOrder_NonCancellableOrder_Returns400() throws Exception {
+        // Given
+        when(orderService.cancelOrder("order-001"))
+                .thenThrow(new InvalidOrderStatusException(OrderStatus.DELIVERED, OrderStatus.CANCELLED));
+
+        // When & Then
+        mockMvc.perform(patch("/api/orders/order-001/cancel"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400));
+    }
+
+    // --- DELETE /api/orders/{id} ---
+
+    @Test
+    @DisplayName("DELETE /api/orders/{id} - ID existente - debe retornar 200")
+    void deleteOrder_ExistingId_Returns200() throws Exception {
+        // Given
+        doNothing().when(orderService).deleteOrder("order-001");
+
+        // When & Then
+        mockMvc.perform(delete("/api/orders/order-001"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.message").value("Pedido eliminado exitosamente"));
+
+        verify(orderService).deleteOrder("order-001");
+    }
+
+    @Test
+    @DisplayName("DELETE /api/orders/{id} - ID no existente - debe retornar 404")
+    void deleteOrder_NonExistingId_Returns404() throws Exception {
+        // Given
+        doThrow(new OrderNotFoundException("nonexistent"))
+                .when(orderService).deleteOrder("nonexistent");
+
+        // When & Then
+        mockMvc.perform(delete("/api/orders/nonexistent"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.status").value(404));
+    }
+
+    // --- GET /api/orders/user/{userId}/count ---
+
+    @Test
+    @DisplayName("GET /api/orders/user/{userId}/count - debe retornar conteo")
+    void countOrdersByUserId_ReturnsCount() throws Exception {
+        // Given
+        when(orderService.countOrdersByUserId(1L)).thenReturn(5L);
+
+        // When & Then
+        mockMvc.perform(get("/api/orders/user/1/count"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").value(5));
+
+        verify(orderService).countOrdersByUserId(1L);
+    }
+
+    // --- GET /api/orders/status/{status}/count ---
+
+    @Test
+    @DisplayName("GET /api/orders/status/{status}/count - debe retornar conteo")
+    void countOrdersByStatus_ReturnsCount() throws Exception {
+        // Given
+        when(orderService.countOrdersByStatus(OrderStatus.PENDING)).thenReturn(3L);
+
+        // When & Then
+        mockMvc.perform(get("/api/orders/status/PENDING/count"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").value(3));
+
+        verify(orderService).countOrdersByStatus(OrderStatus.PENDING);
+    }
+
+    // --- GET /api/orders/user/{userId}/exists ---
+
+    @Test
+    @DisplayName("GET /api/orders/user/{userId}/exists - usuario con pedidos - debe retornar true")
+    void userHasOrders_UserWithOrders_ReturnsTrue() throws Exception {
+        // Given
+        when(orderService.userHasOrders(1L)).thenReturn(true);
+
+        // When & Then
+        mockMvc.perform(get("/api/orders/user/1/exists"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.message").value("El usuario tiene pedidos"))
+                .andExpect(jsonPath("$.data").value(true));
+
+        verify(orderService).userHasOrders(1L);
+    }
+
+    @Test
+    @DisplayName("GET /api/orders/user/{userId}/exists - usuario sin pedidos - debe retornar false")
+    void userHasOrders_UserWithoutOrders_ReturnsFalse() throws Exception {
+        // Given
+        when(orderService.userHasOrders(999L)).thenReturn(false);
+
+        // When & Then
+        mockMvc.perform(get("/api/orders/user/999/exists"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.message").value("El usuario no tiene pedidos"))
+                .andExpect(jsonPath("$.data").value(false));
+    }
+}

--- a/order-service/src/test/java/com/microcommerce/order/dto/response/ApiResponseTest.java
+++ b/order-service/src/test/java/com/microcommerce/order/dto/response/ApiResponseTest.java
@@ -1,0 +1,74 @@
+package com.microcommerce.order.dto.response;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.*;
+
+/**
+ * Unit tests for ApiResponse
+ * Tests unitarios para ApiResponse
+ */
+@DisplayName("ApiResponse Tests")
+class ApiResponseTest {
+
+    @Test
+    @DisplayName("success con data - debe crear respuesta exitosa con mensaje por defecto")
+    void success_WithData_ShouldCreateSuccessResponseWithDefaultMessage() {
+        // When
+        ApiResponse<String> response = ApiResponse.success("test data");
+
+        // Then
+        assertThat(response.isSuccess()).isTrue();
+        assertThat(response.getMessage()).isEqualTo("Operacion exitosa");
+        assertThat(response.getData()).isEqualTo("test data");
+    }
+
+    @Test
+    @DisplayName("success con mensaje y data - debe crear respuesta con mensaje personalizado")
+    void success_WithMessageAndData_ShouldCreateResponseWithCustomMessage() {
+        // When
+        ApiResponse<String> response = ApiResponse.success("Pedido creado", "test data");
+
+        // Then
+        assertThat(response.isSuccess()).isTrue();
+        assertThat(response.getMessage()).isEqualTo("Pedido creado");
+        assertThat(response.getData()).isEqualTo("test data");
+    }
+
+    @Test
+    @DisplayName("error - debe crear respuesta de error sin datos")
+    void error_ShouldCreateErrorResponseWithoutData() {
+        // When
+        ApiResponse<String> response = ApiResponse.error("Error ocurrido");
+
+        // Then
+        assertThat(response.isSuccess()).isFalse();
+        assertThat(response.getMessage()).isEqualTo("Error ocurrido");
+        assertThat(response.getData()).isNull();
+    }
+
+    @Test
+    @DisplayName("constructor por defecto - debe crear instancia vacia")
+    void defaultConstructor_ShouldCreateEmptyInstance() {
+        // When
+        ApiResponse<String> response = new ApiResponse<>();
+
+        // Then
+        assertThat(response.isSuccess()).isFalse();
+        assertThat(response.getMessage()).isNull();
+        assertThat(response.getData()).isNull();
+    }
+
+    @Test
+    @DisplayName("constructor completo - debe crear instancia con todos los campos")
+    void fullConstructor_ShouldCreateInstanceWithAllFields() {
+        // When
+        ApiResponse<Integer> response = new ApiResponse<>(true, "OK", 42);
+
+        // Then
+        assertThat(response.isSuccess()).isTrue();
+        assertThat(response.getMessage()).isEqualTo("OK");
+        assertThat(response.getData()).isEqualTo(42);
+    }
+}

--- a/order-service/src/test/java/com/microcommerce/order/exception/ExceptionTest.java
+++ b/order-service/src/test/java/com/microcommerce/order/exception/ExceptionTest.java
@@ -1,0 +1,63 @@
+package com.microcommerce.order.exception;
+
+import com.microcommerce.order.entity.Order.OrderStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.*;
+
+/**
+ * Unit tests for custom exception classes
+ * Tests unitarios para clases de excepcion personalizadas
+ */
+@DisplayName("Exception Classes Tests")
+class ExceptionTest {
+
+    @Test
+    @DisplayName("OrderNotFoundException - con ID - debe contener mensaje correcto")
+    void orderNotFoundException_WithId_ShouldContainCorrectMessage() {
+        // When
+        OrderNotFoundException exception = new OrderNotFoundException("order-001");
+
+        // Then
+        assertThat(exception.getMessage()).isEqualTo("Pedido no encontrado con id: order-001");
+        assertThat(exception).isInstanceOf(RuntimeException.class);
+    }
+
+    @Test
+    @DisplayName("EmptyOrderException - debe contener mensaje correcto")
+    void emptyOrderException_ShouldContainCorrectMessage() {
+        // When
+        EmptyOrderException exception = new EmptyOrderException();
+
+        // Then
+        assertThat(exception.getMessage()).isEqualTo("El pedido debe contener al menos un item");
+        assertThat(exception).isInstanceOf(RuntimeException.class);
+    }
+
+    @Test
+    @DisplayName("InvalidOrderStatusException - con estados - debe contener mensaje correcto")
+    void invalidOrderStatusException_WithStatuses_ShouldContainCorrectMessage() {
+        // When
+        InvalidOrderStatusException exception = new InvalidOrderStatusException(
+                OrderStatus.PENDING, OrderStatus.SHIPPED);
+
+        // Then
+        assertThat(exception.getMessage())
+                .isEqualTo("Transicion de estado invalida de PENDING a SHIPPED");
+        assertThat(exception).isInstanceOf(RuntimeException.class);
+    }
+
+    @Test
+    @DisplayName("InvalidOrderStatusException - estados terminales - debe contener mensaje correcto")
+    void invalidOrderStatusException_TerminalStates_ShouldContainCorrectMessage() {
+        // When
+        InvalidOrderStatusException exception = new InvalidOrderStatusException(
+                OrderStatus.DELIVERED, OrderStatus.CANCELLED);
+
+        // Then
+        assertThat(exception.getMessage())
+                .contains("DELIVERED")
+                .contains("CANCELLED");
+    }
+}

--- a/order-service/src/test/java/com/microcommerce/order/exception/handler/GlobalExceptionHandlerTest.java
+++ b/order-service/src/test/java/com/microcommerce/order/exception/handler/GlobalExceptionHandlerTest.java
@@ -1,0 +1,122 @@
+package com.microcommerce.order.exception.handler;
+
+import com.microcommerce.order.dto.response.ErrorResponse;
+import com.microcommerce.order.entity.Order.OrderStatus;
+import com.microcommerce.order.exception.EmptyOrderException;
+import com.microcommerce.order.exception.InvalidOrderStatusException;
+import com.microcommerce.order.exception.OrderNotFoundException;
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for GlobalExceptionHandler
+ * Tests unitarios para GlobalExceptionHandler
+ */
+@DisplayName("GlobalExceptionHandler Tests")
+class GlobalExceptionHandlerTest {
+
+    private GlobalExceptionHandler handler;
+    private HttpServletRequest request;
+
+    @BeforeEach
+    void setUp() {
+        handler = new GlobalExceptionHandler();
+        request = mock(HttpServletRequest.class);
+        when(request.getRequestURI()).thenReturn("/api/orders/order-001");
+    }
+
+    @Test
+    @DisplayName("handleOrderNotFoundException - debe retornar 404")
+    void handleOrderNotFoundException_ShouldReturn404() {
+        // Given
+        OrderNotFoundException ex = new OrderNotFoundException("order-001");
+
+        // When
+        ResponseEntity<ErrorResponse> response = handler.handleOrderNotFoundException(ex, request);
+
+        // Then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getStatus()).isEqualTo(404);
+        assertThat(response.getBody().getError()).isEqualTo("Not Found");
+        assertThat(response.getBody().getMessage()).contains("order-001");
+        assertThat(response.getBody().getPath()).isEqualTo("/api/orders/order-001");
+        assertThat(response.getBody().getTimestamp()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("handleInvalidOrderStatusException - debe retornar 400")
+    void handleInvalidOrderStatusException_ShouldReturn400() {
+        // Given
+        InvalidOrderStatusException ex = new InvalidOrderStatusException(
+                OrderStatus.PENDING, OrderStatus.SHIPPED);
+
+        // When
+        ResponseEntity<ErrorResponse> response = handler.handleInvalidOrderStatusException(ex, request);
+
+        // Then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getStatus()).isEqualTo(400);
+        assertThat(response.getBody().getError()).isEqualTo("Bad Request");
+        assertThat(response.getBody().getMessage()).contains("PENDING");
+        assertThat(response.getBody().getMessage()).contains("SHIPPED");
+    }
+
+    @Test
+    @DisplayName("handleEmptyOrderException - debe retornar 400")
+    void handleEmptyOrderException_ShouldReturn400() {
+        // Given
+        EmptyOrderException ex = new EmptyOrderException();
+
+        // When
+        ResponseEntity<ErrorResponse> response = handler.handleEmptyOrderException(ex, request);
+
+        // Then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getStatus()).isEqualTo(400);
+        assertThat(response.getBody().getError()).isEqualTo("Bad Request");
+        assertThat(response.getBody().getMessage()).contains("al menos un item");
+    }
+
+    @Test
+    @DisplayName("handleIllegalArgumentException - debe retornar 400")
+    void handleIllegalArgumentException_ShouldReturn400() {
+        // Given
+        IllegalArgumentException ex = new IllegalArgumentException("Argumento invalido");
+
+        // When
+        ResponseEntity<ErrorResponse> response = handler.handleIllegalArgumentException(ex, request);
+
+        // Then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getStatus()).isEqualTo(400);
+        assertThat(response.getBody().getMessage()).isEqualTo("Argumento invalido");
+    }
+
+    @Test
+    @DisplayName("handleGenericException - debe retornar 500")
+    void handleGenericException_ShouldReturn500() {
+        // Given
+        Exception ex = new Exception("Error inesperado");
+
+        // When
+        ResponseEntity<ErrorResponse> response = handler.handleGenericException(ex, request);
+
+        // Then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getStatus()).isEqualTo(500);
+        assertThat(response.getBody().getError()).isEqualTo("Internal Server Error");
+        assertThat(response.getBody().getMessage()).isEqualTo("Ha ocurrido un error interno en el servidor");
+    }
+}

--- a/order-service/src/test/java/com/microcommerce/order/mapper/OrderMapperTest.java
+++ b/order-service/src/test/java/com/microcommerce/order/mapper/OrderMapperTest.java
@@ -1,0 +1,315 @@
+package com.microcommerce.order.mapper;
+
+import com.microcommerce.order.dto.OrderDTO;
+import com.microcommerce.order.dto.OrderItemDTO;
+import com.microcommerce.order.dto.response.OrderResponse;
+import com.microcommerce.order.dto.response.OrderResponse.OrderItemResponse;
+import com.microcommerce.order.entity.Order;
+import com.microcommerce.order.entity.Order.OrderStatus;
+import com.microcommerce.order.entity.OrderItem;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+
+/**
+ * Unit tests for OrderMapper
+ * Tests unitarios para OrderMapper
+ */
+@DisplayName("OrderMapper Tests")
+class OrderMapperTest {
+
+    private OrderMapper orderMapper;
+    private Order order;
+    private OrderDTO orderDTO;
+    private OrderItem orderItem;
+    private OrderItemDTO orderItemDTO;
+
+    @BeforeEach
+    void setUp() {
+        orderMapper = new OrderMapper();
+
+        orderItem = OrderItem.builder()
+                .productId(1L)
+                .productName("Laptop HP")
+                .quantity(2)
+                .unitPrice(new BigDecimal("999.99"))
+                .subtotal(new BigDecimal("1999.98"))
+                .build();
+
+        order = Order.builder()
+                .id("order-001")
+                .userId(1L)
+                .status(OrderStatus.PENDING)
+                .totalAmount(new BigDecimal("1999.98"))
+                .shippingAddress("Av. Principal 123, Lima, Peru")
+                .paymentMethod("CREDIT_CARD")
+                .transactionId("txn-001")
+                .notes("Test order")
+                .items(List.of(orderItem))
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .shippedAt(null)
+                .deliveredAt(null)
+                .build();
+
+        orderItemDTO = OrderItemDTO.builder()
+                .productId(1L)
+                .productName("Laptop HP")
+                .quantity(2)
+                .unitPrice(new BigDecimal("999.99"))
+                .build();
+
+        orderDTO = OrderDTO.builder()
+                .userId(1L)
+                .shippingAddress("Av. Principal 123, Lima, Peru")
+                .paymentMethod("CREDIT_CARD")
+                .notes("Test order")
+                .items(List.of(orderItemDTO))
+                .build();
+    }
+
+    // --- toEntity tests ---
+
+    @Test
+    @DisplayName("toEntity - DTO valido - debe convertir correctamente")
+    void toEntity_ValidDTO_ConvertsCorrectly() {
+        // When
+        Order result = orderMapper.toEntity(orderDTO);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result.getUserId()).isEqualTo(1L);
+        assertThat(result.getShippingAddress()).isEqualTo("Av. Principal 123, Lima, Peru");
+        assertThat(result.getPaymentMethod()).isEqualTo("CREDIT_CARD");
+        assertThat(result.getNotes()).isEqualTo("Test order");
+        assertThat(result.getItems()).hasSize(1);
+        assertThat(result.getId()).isNull();
+    }
+
+    @Test
+    @DisplayName("toEntity - DTO null - debe retornar null")
+    void toEntity_NullDTO_ReturnsNull() {
+        // When
+        Order result = orderMapper.toEntity(null);
+
+        // Then
+        assertThat(result).isNull();
+    }
+
+    @Test
+    @DisplayName("toEntity - DTO sin items - debe crear orden sin items")
+    void toEntity_DTOWithoutItems_CreatesOrderWithoutItems() {
+        // Given
+        orderDTO.setItems(null);
+
+        // When
+        Order result = orderMapper.toEntity(orderDTO);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result.getItems()).isEmpty();
+    }
+
+    // --- toItemEntity tests ---
+
+    @Test
+    @DisplayName("toItemEntity - DTO valido - debe convertir correctamente")
+    void toItemEntity_ValidDTO_ConvertsCorrectly() {
+        // When
+        OrderItem result = orderMapper.toItemEntity(orderItemDTO);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result.getProductId()).isEqualTo(1L);
+        assertThat(result.getProductName()).isEqualTo("Laptop HP");
+        assertThat(result.getQuantity()).isEqualTo(2);
+        assertThat(result.getUnitPrice()).isEqualByComparingTo(new BigDecimal("999.99"));
+        assertThat(result.getSubtotal()).isEqualByComparingTo(new BigDecimal("1999.98"));
+    }
+
+    @Test
+    @DisplayName("toItemEntity - DTO null - debe retornar null")
+    void toItemEntity_NullDTO_ReturnsNull() {
+        // When
+        OrderItem result = orderMapper.toItemEntity(null);
+
+        // Then
+        assertThat(result).isNull();
+    }
+
+    // --- toResponse tests ---
+
+    @Test
+    @DisplayName("toResponse - entidad valida - debe convertir correctamente")
+    void toResponse_ValidEntity_ConvertsCorrectly() {
+        // When
+        OrderResponse result = orderMapper.toResponse(order);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result.getId()).isEqualTo("order-001");
+        assertThat(result.getUserId()).isEqualTo(1L);
+        assertThat(result.getStatus()).isEqualTo(OrderStatus.PENDING);
+        assertThat(result.getTotalAmount()).isEqualByComparingTo(new BigDecimal("1999.98"));
+        assertThat(result.getShippingAddress()).isEqualTo("Av. Principal 123, Lima, Peru");
+        assertThat(result.getPaymentMethod()).isEqualTo("CREDIT_CARD");
+        assertThat(result.getTransactionId()).isEqualTo("txn-001");
+        assertThat(result.getNotes()).isEqualTo("Test order");
+        assertThat(result.getItems()).hasSize(1);
+        assertThat(result.getItemCount()).isEqualTo(1);
+        assertThat(result.getCreatedAt()).isNotNull();
+        assertThat(result.getUpdatedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("toResponse - entidad null - debe retornar null")
+    void toResponse_NullEntity_ReturnsNull() {
+        // When
+        OrderResponse result = orderMapper.toResponse(null);
+
+        // Then
+        assertThat(result).isNull();
+    }
+
+    @Test
+    @DisplayName("toResponse - orden sin items - debe retornar lista vacia de items")
+    void toResponse_OrderWithoutItems_ReturnsEmptyItemsList() {
+        // Given
+        order.setItems(null);
+
+        // When
+        OrderResponse result = orderMapper.toResponse(order);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result.getItems()).isEmpty();
+        assertThat(result.getItemCount()).isEqualTo(0);
+    }
+
+    // --- toItemResponse tests ---
+
+    @Test
+    @DisplayName("toItemResponse - item valido - debe convertir correctamente")
+    void toItemResponse_ValidItem_ConvertsCorrectly() {
+        // When
+        OrderItemResponse result = orderMapper.toItemResponse(orderItem);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result.getProductId()).isEqualTo(1L);
+        assertThat(result.getProductName()).isEqualTo("Laptop HP");
+        assertThat(result.getQuantity()).isEqualTo(2);
+        assertThat(result.getUnitPrice()).isEqualByComparingTo(new BigDecimal("999.99"));
+        assertThat(result.getSubtotal()).isEqualByComparingTo(new BigDecimal("1999.98"));
+    }
+
+    @Test
+    @DisplayName("toItemResponse - item null - debe retornar null")
+    void toItemResponse_NullItem_ReturnsNull() {
+        // When
+        OrderItemResponse result = orderMapper.toItemResponse(null);
+
+        // Then
+        assertThat(result).isNull();
+    }
+
+    // --- updateEntityFromDto tests ---
+
+    @Test
+    @DisplayName("updateEntityFromDto - debe actualizar solo campos no nulos")
+    void updateEntityFromDto_UpdatesOnlyNonNullFields() {
+        // Given
+        OrderDTO partialDTO = OrderDTO.builder()
+                .shippingAddress("Nueva direccion 456")
+                .paymentMethod("DEBIT_CARD")
+                .build();
+
+        // When
+        orderMapper.updateEntityFromDto(partialDTO, order);
+
+        // Then
+        assertThat(order.getShippingAddress()).isEqualTo("Nueva direccion 456");
+        assertThat(order.getPaymentMethod()).isEqualTo("DEBIT_CARD");
+        assertThat(order.getNotes()).isEqualTo("Test order"); // no cambio
+    }
+
+    @Test
+    @DisplayName("updateEntityFromDto - DTO null - no debe modificar entidad")
+    void updateEntityFromDto_NullDTO_DoesNotModifyEntity() {
+        // Given
+        String originalAddress = order.getShippingAddress();
+
+        // When
+        orderMapper.updateEntityFromDto(null, order);
+
+        // Then
+        assertThat(order.getShippingAddress()).isEqualTo(originalAddress);
+    }
+
+    @Test
+    @DisplayName("updateEntityFromDto - entidad null - no debe lanzar excepcion")
+    void updateEntityFromDto_NullEntity_DoesNotThrowException() {
+        // When & Then
+        assertThatCode(() -> orderMapper.updateEntityFromDto(orderDTO, null))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("updateEntityFromDto - solo notes - debe actualizar solo notes")
+    void updateEntityFromDto_OnlyNotes_UpdatesOnlyNotes() {
+        // Given
+        OrderDTO partialDTO = OrderDTO.builder()
+                .notes("Nuevas notas")
+                .build();
+
+        // When
+        orderMapper.updateEntityFromDto(partialDTO, order);
+
+        // Then
+        assertThat(order.getNotes()).isEqualTo("Nuevas notas");
+        assertThat(order.getShippingAddress()).isEqualTo("Av. Principal 123, Lima, Peru");
+        assertThat(order.getPaymentMethod()).isEqualTo("CREDIT_CARD");
+    }
+
+    // --- toResponseList tests ---
+
+    @Test
+    @DisplayName("toResponseList - lista valida - debe convertir correctamente")
+    void toResponseList_ValidList_ConvertsCorrectly() {
+        // Given
+        List<Order> orders = List.of(order, order);
+
+        // When
+        List<OrderResponse> result = orderMapper.toResponseList(orders);
+
+        // Then
+        assertThat(result).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("toResponseList - lista null - debe retornar lista vacia")
+    void toResponseList_NullList_ReturnsEmptyList() {
+        // When
+        List<OrderResponse> result = orderMapper.toResponseList(null);
+
+        // Then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("toResponseList - lista vacia - debe retornar lista vacia")
+    void toResponseList_EmptyList_ReturnsEmptyList() {
+        // When
+        List<OrderResponse> result = orderMapper.toResponseList(Collections.emptyList());
+
+        // Then
+        assertThat(result).isEmpty();
+    }
+}

--- a/order-service/src/test/java/com/microcommerce/order/repository/OrderRepositoryIntegrationTest.java
+++ b/order-service/src/test/java/com/microcommerce/order/repository/OrderRepositoryIntegrationTest.java
@@ -1,0 +1,324 @@
+package com.microcommerce.order.repository;
+
+import com.microcommerce.order.config.MongoConfig;
+import com.microcommerce.order.entity.Order;
+import com.microcommerce.order.entity.Order.OrderStatus;
+import com.microcommerce.order.entity.OrderItem;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+
+/**
+ * Integration tests for OrderRepository using TestContainers
+ * Tests de integracion para OrderRepository usando TestContainers
+ */
+@DataMongoTest
+@Testcontainers
+@ActiveProfiles("test-tc")
+@Import(MongoConfig.class)
+@DisplayName("OrderRepository Integration Tests")
+class OrderRepositoryIntegrationTest {
+
+    @Container
+    static MongoDBContainer mongodb = new MongoDBContainer("mongo:7.0");
+
+    @DynamicPropertySource
+    static void configureProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.data.mongodb.uri", mongodb::getReplicaSetUrl);
+    }
+
+    @Autowired
+    private OrderRepository orderRepository;
+
+    @BeforeEach
+    void setUp() {
+        orderRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("Guardar pedido - debe persistir correctamente")
+    void saveOrder_ShouldPersistCorrectly() {
+        // Given
+        Order order = createOrder(1L, OrderStatus.PENDING, "Av. Principal 123");
+
+        // When
+        Order saved = orderRepository.save(order);
+
+        // Then
+        assertThat(saved.getId()).isNotNull();
+        assertThat(saved.getUserId()).isEqualTo(1L);
+        assertThat(saved.getStatus()).isEqualTo(OrderStatus.PENDING);
+        assertThat(saved.getCreatedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("findById - debe encontrar pedido existente")
+    void findById_ShouldFindExistingOrder() {
+        // Given
+        Order saved = orderRepository.save(createOrder(1L, OrderStatus.PENDING, "Av. Principal 123"));
+
+        // When
+        Optional<Order> found = orderRepository.findById(saved.getId());
+
+        // Then
+        assertThat(found).isPresent();
+        assertThat(found.get().getUserId()).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("findById - ID no existente - debe retornar vacio")
+    void findById_NonExistingId_ShouldReturnEmpty() {
+        // When
+        Optional<Order> found = orderRepository.findById("nonexistent-id");
+
+        // Then
+        assertThat(found).isEmpty();
+    }
+
+    @Test
+    @DisplayName("findByUserId - debe retornar pedidos del usuario")
+    void findByUserId_ShouldReturnUserOrders() {
+        // Given
+        createAndSaveOrder(1L, OrderStatus.PENDING, "Direccion 1");
+        createAndSaveOrder(1L, OrderStatus.PAID, "Direccion 2");
+        createAndSaveOrder(2L, OrderStatus.PENDING, "Direccion 3");
+
+        // When
+        List<Order> user1Orders = orderRepository.findByUserId(1L);
+        List<Order> user2Orders = orderRepository.findByUserId(2L);
+
+        // Then
+        assertThat(user1Orders).hasSize(2);
+        assertThat(user2Orders).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("findByUserIdAndStatus - debe filtrar por usuario y estado")
+    void findByUserIdAndStatus_ShouldFilterByUserAndStatus() {
+        // Given
+        createAndSaveOrder(1L, OrderStatus.PENDING, "Direccion 1");
+        createAndSaveOrder(1L, OrderStatus.PAID, "Direccion 2");
+        createAndSaveOrder(1L, OrderStatus.PENDING, "Direccion 3");
+
+        // When
+        List<Order> pendingOrders = orderRepository.findByUserIdAndStatus(1L, OrderStatus.PENDING);
+        List<Order> paidOrders = orderRepository.findByUserIdAndStatus(1L, OrderStatus.PAID);
+
+        // Then
+        assertThat(pendingOrders).hasSize(2);
+        assertThat(paidOrders).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("findByStatus - debe retornar pedidos por estado")
+    void findByStatus_ShouldReturnOrdersByStatus() {
+        // Given
+        createAndSaveOrder(1L, OrderStatus.PENDING, "Direccion 1");
+        createAndSaveOrder(2L, OrderStatus.PENDING, "Direccion 2");
+        createAndSaveOrder(1L, OrderStatus.PAID, "Direccion 3");
+
+        // When
+        List<Order> pendingOrders = orderRepository.findByStatus(OrderStatus.PENDING);
+
+        // Then
+        assertThat(pendingOrders).hasSize(2);
+        assertThat(pendingOrders).allMatch(o -> o.getStatus() == OrderStatus.PENDING);
+    }
+
+    @Test
+    @DisplayName("findByCreatedAtBetween - debe retornar pedidos en rango de fechas")
+    void findByCreatedAtBetween_ShouldReturnOrdersInDateRange() {
+        // Given
+        createAndSaveOrder(1L, OrderStatus.PENDING, "Direccion 1");
+        createAndSaveOrder(2L, OrderStatus.PAID, "Direccion 2");
+
+        LocalDateTime start = LocalDateTime.now().minusMinutes(5);
+        LocalDateTime end = LocalDateTime.now().plusMinutes(5);
+
+        // When
+        List<Order> orders = orderRepository.findByCreatedAtBetween(start, end);
+
+        // Then
+        assertThat(orders).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("findByUserIdOrderByCreatedAtDesc - debe ordenar por fecha descendente")
+    void findByUserIdOrderByCreatedAtDesc_ShouldOrderByDateDesc() throws InterruptedException {
+        // Given
+        Order first = createAndSaveOrder(1L, OrderStatus.PENDING, "Direccion 1");
+        Thread.sleep(50);
+        Order second = createAndSaveOrder(1L, OrderStatus.PAID, "Direccion 2");
+
+        // When
+        List<Order> orders = orderRepository.findByUserIdOrderByCreatedAtDesc(1L);
+
+        // Then
+        assertThat(orders).hasSize(2);
+        assertThat(orders.get(0).getCreatedAt()).isAfterOrEqualTo(orders.get(1).getCreatedAt());
+    }
+
+    @Test
+    @DisplayName("countByUserId - debe contar pedidos del usuario")
+    void countByUserId_ShouldCountUserOrders() {
+        // Given
+        createAndSaveOrder(1L, OrderStatus.PENDING, "Direccion 1");
+        createAndSaveOrder(1L, OrderStatus.PAID, "Direccion 2");
+        createAndSaveOrder(2L, OrderStatus.PENDING, "Direccion 3");
+
+        // When
+        long user1Count = orderRepository.countByUserId(1L);
+        long user2Count = orderRepository.countByUserId(2L);
+        long user3Count = orderRepository.countByUserId(3L);
+
+        // Then
+        assertThat(user1Count).isEqualTo(2);
+        assertThat(user2Count).isEqualTo(1);
+        assertThat(user3Count).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("countByStatus - debe contar pedidos por estado")
+    void countByStatus_ShouldCountOrdersByStatus() {
+        // Given
+        createAndSaveOrder(1L, OrderStatus.PENDING, "Direccion 1");
+        createAndSaveOrder(2L, OrderStatus.PENDING, "Direccion 2");
+        createAndSaveOrder(1L, OrderStatus.PAID, "Direccion 3");
+
+        // When
+        long pendingCount = orderRepository.countByStatus(OrderStatus.PENDING);
+        long paidCount = orderRepository.countByStatus(OrderStatus.PAID);
+        long cancelledCount = orderRepository.countByStatus(OrderStatus.CANCELLED);
+
+        // Then
+        assertThat(pendingCount).isEqualTo(2);
+        assertThat(paidCount).isEqualTo(1);
+        assertThat(cancelledCount).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("existsByUserId - debe verificar si el usuario tiene pedidos")
+    void existsByUserId_ShouldCheckIfUserHasOrders() {
+        // Given
+        createAndSaveOrder(1L, OrderStatus.PENDING, "Direccion 1");
+
+        // When
+        boolean exists = orderRepository.existsByUserId(1L);
+        boolean notExists = orderRepository.existsByUserId(999L);
+
+        // Then
+        assertThat(exists).isTrue();
+        assertThat(notExists).isFalse();
+    }
+
+    @Test
+    @DisplayName("Actualizar pedido - debe persistir cambios")
+    void updateOrder_ShouldPersistChanges() {
+        // Given
+        Order saved = createAndSaveOrder(1L, OrderStatus.PENDING, "Direccion original");
+        String orderId = saved.getId();
+
+        // When
+        saved.setStatus(OrderStatus.PAID);
+        saved.setShippingAddress("Direccion actualizada");
+        orderRepository.save(saved);
+
+        // Then
+        Order updated = orderRepository.findById(orderId).orElseThrow();
+        assertThat(updated.getStatus()).isEqualTo(OrderStatus.PAID);
+        assertThat(updated.getShippingAddress()).isEqualTo("Direccion actualizada");
+    }
+
+    @Test
+    @DisplayName("Eliminar pedido - debe remover de base de datos")
+    void deleteOrder_ShouldRemoveFromDatabase() {
+        // Given
+        Order saved = createAndSaveOrder(1L, OrderStatus.PENDING, "Direccion 1");
+        String orderId = saved.getId();
+
+        // When
+        orderRepository.deleteById(orderId);
+
+        // Then
+        Optional<Order> deleted = orderRepository.findById(orderId);
+        assertThat(deleted).isEmpty();
+    }
+
+    @Test
+    @DisplayName("findByUserId - usuario sin pedidos - debe retornar lista vacia")
+    void findByUserId_UserWithoutOrders_ShouldReturnEmptyList() {
+        // When
+        List<Order> orders = orderRepository.findByUserId(999L);
+
+        // Then
+        assertThat(orders).isEmpty();
+    }
+
+    @Test
+    @DisplayName("findByStatus - estado sin pedidos - debe retornar lista vacia")
+    void findByStatus_StatusWithoutOrders_ShouldReturnEmptyList() {
+        // When
+        List<Order> orders = orderRepository.findByStatus(OrderStatus.SHIPPED);
+
+        // Then
+        assertThat(orders).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Guardar pedido con items - debe persistir items embebidos")
+    void saveOrderWithItems_ShouldPersistEmbeddedItems() {
+        // Given
+        Order order = createOrder(1L, OrderStatus.PENDING, "Av. Principal 123");
+
+        // When
+        Order saved = orderRepository.save(order);
+
+        // Then
+        Order found = orderRepository.findById(saved.getId()).orElseThrow();
+        assertThat(found.getItems()).hasSize(1);
+        assertThat(found.getItems().get(0).getProductName()).isEqualTo("Laptop HP");
+        assertThat(found.getItems().get(0).getQuantity()).isEqualTo(2);
+    }
+
+    // Helper methods
+
+    private Order createOrder(Long userId, OrderStatus status, String address) {
+        OrderItem item = OrderItem.builder()
+                .productId(1L)
+                .productName("Laptop HP")
+                .quantity(2)
+                .unitPrice(new BigDecimal("999.99"))
+                .subtotal(new BigDecimal("1999.98"))
+                .build();
+
+        return Order.builder()
+                .userId(userId)
+                .status(status)
+                .shippingAddress(address)
+                .paymentMethod("CREDIT_CARD")
+                .notes("Test order")
+                .items(new java.util.ArrayList<>(List.of(item)))
+                .totalAmount(new BigDecimal("1999.98"))
+                .build();
+    }
+
+    private Order createAndSaveOrder(Long userId, OrderStatus status, String address) {
+        return orderRepository.save(createOrder(userId, status, address));
+    }
+}

--- a/order-service/src/test/java/com/microcommerce/order/service/OrderServiceImplTest.java
+++ b/order-service/src/test/java/com/microcommerce/order/service/OrderServiceImplTest.java
@@ -1,0 +1,595 @@
+package com.microcommerce.order.service;
+
+import com.microcommerce.order.dto.OrderDTO;
+import com.microcommerce.order.dto.OrderItemDTO;
+import com.microcommerce.order.entity.Order;
+import com.microcommerce.order.entity.Order.OrderStatus;
+import com.microcommerce.order.entity.OrderItem;
+import com.microcommerce.order.exception.EmptyOrderException;
+import com.microcommerce.order.exception.InvalidOrderStatusException;
+import com.microcommerce.order.exception.OrderNotFoundException;
+import com.microcommerce.order.mapper.OrderMapper;
+import com.microcommerce.order.repository.OrderRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for OrderServiceImpl
+ * Tests unitarios para OrderServiceImpl
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("OrderServiceImpl Tests")
+class OrderServiceImplTest {
+
+    @Mock
+    private OrderRepository orderRepository;
+
+    @Mock
+    private OrderMapper orderMapper;
+
+    @InjectMocks
+    private OrderServiceImpl orderService;
+
+    private Order order;
+    private OrderDTO orderDTO;
+    private OrderItem orderItem;
+    private OrderItemDTO orderItemDTO;
+
+    @BeforeEach
+    void setUp() {
+        orderItem = OrderItem.builder()
+                .productId(1L)
+                .productName("Laptop HP")
+                .quantity(2)
+                .unitPrice(new BigDecimal("999.99"))
+                .subtotal(new BigDecimal("1999.98"))
+                .build();
+
+        order = Order.builder()
+                .id("order-001")
+                .userId(1L)
+                .status(OrderStatus.PENDING)
+                .shippingAddress("Av. Principal 123, Lima, Peru")
+                .paymentMethod("CREDIT_CARD")
+                .notes("Test order")
+                .items(new java.util.ArrayList<>(List.of(orderItem)))
+                .totalAmount(new BigDecimal("1999.98"))
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build();
+
+        orderItemDTO = OrderItemDTO.builder()
+                .productId(1L)
+                .productName("Laptop HP")
+                .quantity(2)
+                .unitPrice(new BigDecimal("999.99"))
+                .build();
+
+        orderDTO = OrderDTO.builder()
+                .userId(1L)
+                .shippingAddress("Av. Principal 123, Lima, Peru")
+                .paymentMethod("CREDIT_CARD")
+                .notes("Test order")
+                .items(List.of(orderItemDTO))
+                .build();
+    }
+
+    // --- createOrder tests ---
+
+    @Test
+    @DisplayName("createOrder - DTO valido - debe retornar pedido creado")
+    void createOrder_ValidDTO_ReturnsOrder() {
+        // Given
+        when(orderMapper.toEntity(any(OrderDTO.class))).thenReturn(order);
+        when(orderRepository.save(any(Order.class))).thenReturn(order);
+
+        // When
+        Order result = orderService.createOrder(orderDTO);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result.getId()).isEqualTo("order-001");
+        assertThat(result.getUserId()).isEqualTo(1L);
+        assertThat(result.getStatus()).isEqualTo(OrderStatus.PENDING);
+        verify(orderMapper).toEntity(orderDTO);
+        verify(orderRepository).save(any(Order.class));
+    }
+
+    @Test
+    @DisplayName("createOrder - items null - debe lanzar EmptyOrderException")
+    void createOrder_NullItems_ThrowsEmptyOrderException() {
+        // Given
+        orderDTO.setItems(null);
+
+        // When & Then
+        assertThatThrownBy(() -> orderService.createOrder(orderDTO))
+                .isInstanceOf(EmptyOrderException.class);
+        verify(orderRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("createOrder - items vacios - debe lanzar EmptyOrderException")
+    void createOrder_EmptyItems_ThrowsEmptyOrderException() {
+        // Given
+        orderDTO.setItems(Collections.emptyList());
+
+        // When & Then
+        assertThatThrownBy(() -> orderService.createOrder(orderDTO))
+                .isInstanceOf(EmptyOrderException.class);
+        verify(orderRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("createOrder - debe establecer estado PENDING")
+    void createOrder_ShouldSetStatusPending() {
+        // Given
+        when(orderMapper.toEntity(any(OrderDTO.class))).thenReturn(order);
+        when(orderRepository.save(any(Order.class))).thenReturn(order);
+
+        // When
+        Order result = orderService.createOrder(orderDTO);
+
+        // Then
+        assertThat(result.getStatus()).isEqualTo(OrderStatus.PENDING);
+    }
+
+    // --- getOrderById tests ---
+
+    @Test
+    @DisplayName("getOrderById - ID existente - debe retornar pedido")
+    void getOrderById_ExistingId_ReturnsOrder() {
+        // Given
+        when(orderRepository.findById("order-001")).thenReturn(Optional.of(order));
+
+        // When
+        Order result = orderService.getOrderById("order-001");
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result.getId()).isEqualTo("order-001");
+        verify(orderRepository).findById("order-001");
+    }
+
+    @Test
+    @DisplayName("getOrderById - ID no existente - debe lanzar OrderNotFoundException")
+    void getOrderById_NonExistingId_ThrowsException() {
+        // Given
+        when(orderRepository.findById("nonexistent")).thenReturn(Optional.empty());
+
+        // When & Then
+        assertThatThrownBy(() -> orderService.getOrderById("nonexistent"))
+                .isInstanceOf(OrderNotFoundException.class)
+                .hasMessageContaining("nonexistent");
+    }
+
+    // --- getAllOrders tests ---
+
+    @Test
+    @DisplayName("getAllOrders - debe retornar lista de pedidos")
+    void getAllOrders_ReturnsOrderList() {
+        // Given
+        List<Order> orders = Arrays.asList(order, order);
+        when(orderRepository.findAll()).thenReturn(orders);
+
+        // When
+        List<Order> result = orderService.getAllOrders();
+
+        // Then
+        assertThat(result).hasSize(2);
+        verify(orderRepository).findAll();
+    }
+
+    @Test
+    @DisplayName("getAllOrders - lista vacia - debe retornar lista vacia")
+    void getAllOrders_EmptyList_ReturnsEmptyList() {
+        // Given
+        when(orderRepository.findAll()).thenReturn(List.of());
+
+        // When
+        List<Order> result = orderService.getAllOrders();
+
+        // Then
+        assertThat(result).isEmpty();
+    }
+
+    // --- getOrdersByUserId tests ---
+
+    @Test
+    @DisplayName("getOrdersByUserId - usuario con pedidos - debe retornar lista")
+    void getOrdersByUserId_UserWithOrders_ReturnsList() {
+        // Given
+        when(orderRepository.findByUserId(1L)).thenReturn(List.of(order));
+
+        // When
+        List<Order> result = orderService.getOrdersByUserId(1L);
+
+        // Then
+        assertThat(result).hasSize(1);
+        verify(orderRepository).findByUserId(1L);
+    }
+
+    // --- getOrdersByUserIdAndStatus tests ---
+
+    @Test
+    @DisplayName("getOrdersByUserIdAndStatus - debe filtrar por usuario y estado")
+    void getOrdersByUserIdAndStatus_ReturnsFilteredList() {
+        // Given
+        when(orderRepository.findByUserIdAndStatus(1L, OrderStatus.PENDING))
+                .thenReturn(List.of(order));
+
+        // When
+        List<Order> result = orderService.getOrdersByUserIdAndStatus(1L, OrderStatus.PENDING);
+
+        // Then
+        assertThat(result).hasSize(1);
+        verify(orderRepository).findByUserIdAndStatus(1L, OrderStatus.PENDING);
+    }
+
+    // --- getOrdersByStatus tests ---
+
+    @Test
+    @DisplayName("getOrdersByStatus - debe retornar pedidos por estado")
+    void getOrdersByStatus_ReturnsOrdersByStatus() {
+        // Given
+        when(orderRepository.findByStatus(OrderStatus.PENDING)).thenReturn(List.of(order));
+
+        // When
+        List<Order> result = orderService.getOrdersByStatus(OrderStatus.PENDING);
+
+        // Then
+        assertThat(result).hasSize(1);
+        verify(orderRepository).findByStatus(OrderStatus.PENDING);
+    }
+
+    // --- getRecentOrdersByUserId tests ---
+
+    @Test
+    @DisplayName("getRecentOrdersByUserId - debe retornar pedidos recientes del usuario")
+    void getRecentOrdersByUserId_ReturnsRecentOrders() {
+        // Given
+        when(orderRepository.findByUserIdOrderByCreatedAtDesc(1L)).thenReturn(List.of(order));
+
+        // When
+        List<Order> result = orderService.getRecentOrdersByUserId(1L);
+
+        // Then
+        assertThat(result).hasSize(1);
+        verify(orderRepository).findByUserIdOrderByCreatedAtDesc(1L);
+    }
+
+    // --- getOrdersByDateRange tests ---
+
+    @Test
+    @DisplayName("getOrdersByDateRange - debe retornar pedidos en rango de fechas")
+    void getOrdersByDateRange_ReturnsOrdersInRange() {
+        // Given
+        LocalDateTime start = LocalDateTime.now().minusDays(7);
+        LocalDateTime end = LocalDateTime.now();
+        when(orderRepository.findByCreatedAtBetween(start, end)).thenReturn(List.of(order));
+
+        // When
+        List<Order> result = orderService.getOrdersByDateRange(start, end);
+
+        // Then
+        assertThat(result).hasSize(1);
+        verify(orderRepository).findByCreatedAtBetween(start, end);
+    }
+
+    // --- updateOrder tests ---
+
+    @Test
+    @DisplayName("updateOrder - pedido PENDING - debe actualizar correctamente")
+    void updateOrder_PendingOrder_UpdatesSuccessfully() {
+        // Given
+        when(orderRepository.findById("order-001")).thenReturn(Optional.of(order));
+        when(orderRepository.save(any(Order.class))).thenReturn(order);
+
+        // When
+        Order result = orderService.updateOrder("order-001", orderDTO);
+
+        // Then
+        assertThat(result).isNotNull();
+        verify(orderMapper).updateEntityFromDto(orderDTO, order);
+        verify(orderRepository).save(any(Order.class));
+    }
+
+    @Test
+    @DisplayName("updateOrder - pedido no PENDING - debe lanzar InvalidOrderStatusException")
+    void updateOrder_NonPendingOrder_ThrowsException() {
+        // Given
+        order.setStatus(OrderStatus.PAID);
+        when(orderRepository.findById("order-001")).thenReturn(Optional.of(order));
+
+        // When & Then
+        assertThatThrownBy(() -> orderService.updateOrder("order-001", orderDTO))
+                .isInstanceOf(InvalidOrderStatusException.class);
+        verify(orderRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("updateOrder - ID no existente - debe lanzar OrderNotFoundException")
+    void updateOrder_NonExistingId_ThrowsException() {
+        // Given
+        when(orderRepository.findById("nonexistent")).thenReturn(Optional.empty());
+
+        // When & Then
+        assertThatThrownBy(() -> orderService.updateOrder("nonexistent", orderDTO))
+                .isInstanceOf(OrderNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("updateOrder - con nuevos items - debe recalcular totales")
+    void updateOrder_WithNewItems_RecalculatesTotals() {
+        // Given
+        when(orderRepository.findById("order-001")).thenReturn(Optional.of(order));
+        when(orderRepository.save(any(Order.class))).thenReturn(order);
+        when(orderMapper.toItemEntity(any(OrderItemDTO.class))).thenReturn(orderItem);
+
+        // When
+        Order result = orderService.updateOrder("order-001", orderDTO);
+
+        // Then
+        assertThat(result).isNotNull();
+        verify(orderRepository).save(any(Order.class));
+    }
+
+    @Test
+    @DisplayName("updateOrder - sin items en DTO - no debe actualizar items")
+    void updateOrder_WithoutItems_ShouldNotUpdateItems() {
+        // Given
+        orderDTO.setItems(null);
+        when(orderRepository.findById("order-001")).thenReturn(Optional.of(order));
+        when(orderRepository.save(any(Order.class))).thenReturn(order);
+
+        // When
+        Order result = orderService.updateOrder("order-001", orderDTO);
+
+        // Then
+        assertThat(result).isNotNull();
+        verify(orderMapper, never()).toItemEntity(any());
+    }
+
+    // --- updateOrderStatus tests ---
+
+    @Test
+    @DisplayName("updateOrderStatus - PENDING a PAID - transicion valida")
+    void updateOrderStatus_PendingToPaid_ValidTransition() {
+        // Given
+        when(orderRepository.findById("order-001")).thenReturn(Optional.of(order));
+        when(orderRepository.save(any(Order.class))).thenReturn(order);
+
+        // When
+        Order result = orderService.updateOrderStatus("order-001", OrderStatus.PAID);
+
+        // Then
+        assertThat(result.getStatus()).isEqualTo(OrderStatus.PAID);
+        verify(orderRepository).save(any(Order.class));
+    }
+
+    @Test
+    @DisplayName("updateOrderStatus - PENDING a CANCELLED - transicion valida")
+    void updateOrderStatus_PendingToCancelled_ValidTransition() {
+        // Given
+        when(orderRepository.findById("order-001")).thenReturn(Optional.of(order));
+        when(orderRepository.save(any(Order.class))).thenReturn(order);
+
+        // When
+        Order result = orderService.updateOrderStatus("order-001", OrderStatus.CANCELLED);
+
+        // Then
+        assertThat(result.getStatus()).isEqualTo(OrderStatus.CANCELLED);
+    }
+
+    @Test
+    @DisplayName("updateOrderStatus - PENDING a SHIPPED - transicion invalida")
+    void updateOrderStatus_PendingToShipped_InvalidTransition() {
+        // Given
+        when(orderRepository.findById("order-001")).thenReturn(Optional.of(order));
+
+        // When & Then
+        assertThatThrownBy(() -> orderService.updateOrderStatus("order-001", OrderStatus.SHIPPED))
+                .isInstanceOf(InvalidOrderStatusException.class);
+        verify(orderRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("updateOrderStatus - DELIVERED terminal - no permite transiciones")
+    void updateOrderStatus_DeliveredTerminal_NoTransitionsAllowed() {
+        // Given
+        order.setStatus(OrderStatus.DELIVERED);
+        when(orderRepository.findById("order-001")).thenReturn(Optional.of(order));
+
+        // When & Then
+        assertThatThrownBy(() -> orderService.updateOrderStatus("order-001", OrderStatus.CANCELLED))
+                .isInstanceOf(InvalidOrderStatusException.class);
+    }
+
+    @Test
+    @DisplayName("updateOrderStatus - CANCELLED terminal - no permite transiciones")
+    void updateOrderStatus_CancelledTerminal_NoTransitionsAllowed() {
+        // Given
+        order.setStatus(OrderStatus.CANCELLED);
+        when(orderRepository.findById("order-001")).thenReturn(Optional.of(order));
+
+        // When & Then
+        assertThatThrownBy(() -> orderService.updateOrderStatus("order-001", OrderStatus.PENDING))
+                .isInstanceOf(InvalidOrderStatusException.class);
+    }
+
+    @Test
+    @DisplayName("updateOrderStatus - a SHIPPED - debe establecer shippedAt")
+    void updateOrderStatus_ToShipped_SetsShippedAt() {
+        // Given
+        order.setStatus(OrderStatus.PROCESSING);
+        when(orderRepository.findById("order-001")).thenReturn(Optional.of(order));
+        when(orderRepository.save(any(Order.class))).thenReturn(order);
+
+        // When
+        Order result = orderService.updateOrderStatus("order-001", OrderStatus.SHIPPED);
+
+        // Then
+        assertThat(result.getShippedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("updateOrderStatus - a DELIVERED - debe establecer deliveredAt")
+    void updateOrderStatus_ToDelivered_SetsDeliveredAt() {
+        // Given
+        order.setStatus(OrderStatus.SHIPPED);
+        when(orderRepository.findById("order-001")).thenReturn(Optional.of(order));
+        when(orderRepository.save(any(Order.class))).thenReturn(order);
+
+        // When
+        Order result = orderService.updateOrderStatus("order-001", OrderStatus.DELIVERED);
+
+        // Then
+        assertThat(result.getDeliveredAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("updateOrderStatus - PAID a PROCESSING - transicion valida")
+    void updateOrderStatus_PaidToProcessing_ValidTransition() {
+        // Given
+        order.setStatus(OrderStatus.PAID);
+        when(orderRepository.findById("order-001")).thenReturn(Optional.of(order));
+        when(orderRepository.save(any(Order.class))).thenReturn(order);
+
+        // When
+        Order result = orderService.updateOrderStatus("order-001", OrderStatus.PROCESSING);
+
+        // Then
+        assertThat(result.getStatus()).isEqualTo(OrderStatus.PROCESSING);
+    }
+
+    // --- cancelOrder tests ---
+
+    @Test
+    @DisplayName("cancelOrder - pedido PENDING - debe cancelar")
+    void cancelOrder_PendingOrder_CancelsSuccessfully() {
+        // Given
+        when(orderRepository.findById("order-001")).thenReturn(Optional.of(order));
+        when(orderRepository.save(any(Order.class))).thenReturn(order);
+
+        // When
+        Order result = orderService.cancelOrder("order-001");
+
+        // Then
+        assertThat(result.getStatus()).isEqualTo(OrderStatus.CANCELLED);
+    }
+
+    @Test
+    @DisplayName("cancelOrder - pedido DELIVERED - debe lanzar excepcion")
+    void cancelOrder_DeliveredOrder_ThrowsException() {
+        // Given
+        order.setStatus(OrderStatus.DELIVERED);
+        when(orderRepository.findById("order-001")).thenReturn(Optional.of(order));
+
+        // When & Then
+        assertThatThrownBy(() -> orderService.cancelOrder("order-001"))
+                .isInstanceOf(InvalidOrderStatusException.class);
+    }
+
+    // --- deleteOrder tests ---
+
+    @Test
+    @DisplayName("deleteOrder - ID existente - debe eliminar pedido")
+    void deleteOrder_ExistingId_DeletesOrder() {
+        // Given
+        when(orderRepository.existsById("order-001")).thenReturn(true);
+
+        // When
+        orderService.deleteOrder("order-001");
+
+        // Then
+        verify(orderRepository).deleteById("order-001");
+    }
+
+    @Test
+    @DisplayName("deleteOrder - ID no existente - debe lanzar OrderNotFoundException")
+    void deleteOrder_NonExistingId_ThrowsException() {
+        // Given
+        when(orderRepository.existsById("nonexistent")).thenReturn(false);
+
+        // When & Then
+        assertThatThrownBy(() -> orderService.deleteOrder("nonexistent"))
+                .isInstanceOf(OrderNotFoundException.class);
+        verify(orderRepository, never()).deleteById(anyString());
+    }
+
+    // --- countOrdersByUserId tests ---
+
+    @Test
+    @DisplayName("countOrdersByUserId - debe retornar cantidad correcta")
+    void countOrdersByUserId_ReturnsCorrectCount() {
+        // Given
+        when(orderRepository.countByUserId(1L)).thenReturn(5L);
+
+        // When
+        long result = orderService.countOrdersByUserId(1L);
+
+        // Then
+        assertThat(result).isEqualTo(5L);
+        verify(orderRepository).countByUserId(1L);
+    }
+
+    // --- countOrdersByStatus tests ---
+
+    @Test
+    @DisplayName("countOrdersByStatus - debe retornar cantidad correcta")
+    void countOrdersByStatus_ReturnsCorrectCount() {
+        // Given
+        when(orderRepository.countByStatus(OrderStatus.PENDING)).thenReturn(3L);
+
+        // When
+        long result = orderService.countOrdersByStatus(OrderStatus.PENDING);
+
+        // Then
+        assertThat(result).isEqualTo(3L);
+        verify(orderRepository).countByStatus(OrderStatus.PENDING);
+    }
+
+    // --- userHasOrders tests ---
+
+    @Test
+    @DisplayName("userHasOrders - usuario con pedidos - debe retornar true")
+    void userHasOrders_UserWithOrders_ReturnsTrue() {
+        // Given
+        when(orderRepository.existsByUserId(1L)).thenReturn(true);
+
+        // When
+        boolean result = orderService.userHasOrders(1L);
+
+        // Then
+        assertThat(result).isTrue();
+        verify(orderRepository).existsByUserId(1L);
+    }
+
+    @Test
+    @DisplayName("userHasOrders - usuario sin pedidos - debe retornar false")
+    void userHasOrders_UserWithoutOrders_ReturnsFalse() {
+        // Given
+        when(orderRepository.existsByUserId(999L)).thenReturn(false);
+
+        // When
+        boolean result = orderService.userHasOrders(999L);
+
+        // Then
+        assertThat(result).isFalse();
+    }
+}

--- a/order-service/src/test/resources/application-test-nodb.yml
+++ b/order-service/src/test/resources/application-test-nodb.yml
@@ -1,0 +1,10 @@
+# Test profile without DB (for controller tests)
+# Perfil de test sin base de datos (para tests de controlador)
+spring:
+  autoconfigure:
+    exclude:
+      - org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration
+      - org.springframework.boot.autoconfigure.data.mongo.MongoDataAutoConfiguration
+  data:
+    mongodb:
+      uri: mongodb://localhost:27017/testdb

--- a/order-service/src/test/resources/application-test-tc.yml
+++ b/order-service/src/test/resources/application-test-tc.yml
@@ -1,0 +1,6 @@
+# Test profile with TestContainers (MongoDB via TC)
+# Perfil de test con TestContainers (MongoDB via TC)
+spring:
+  data:
+    mongodb:
+      auto-index-creation: true

--- a/order-service/src/test/resources/application.yml
+++ b/order-service/src/test/resources/application.yml
@@ -1,0 +1,18 @@
+# Default test configuration
+# Configuracion de test por defecto
+
+spring:
+  application:
+    name: order-service-test
+
+  cloud:
+    config:
+      enabled: false
+
+eureka:
+  client:
+    enabled: false
+
+logging:
+  level:
+    com.microcommerce.order: DEBUG

--- a/order-service/src/test/resources/mock/order-create.json
+++ b/order-service/src/test/resources/mock/order-create.json
@@ -1,0 +1,20 @@
+{
+  "userId": 1,
+  "shippingAddress": "Av. Principal 123, Lima, Peru",
+  "paymentMethod": "CREDIT_CARD",
+  "notes": "Entregar en horario de oficina",
+  "items": [
+    {
+      "productId": 1,
+      "productName": "Laptop HP",
+      "quantity": 2,
+      "unitPrice": 999.99
+    },
+    {
+      "productId": 2,
+      "productName": "Mouse Logitech",
+      "quantity": 1,
+      "unitPrice": 29.99
+    }
+  ]
+}

--- a/order-service/src/test/resources/mock/order-update.json
+++ b/order-service/src/test/resources/mock/order-update.json
@@ -1,0 +1,14 @@
+{
+  "userId": 1,
+  "shippingAddress": "Av. Secundaria 456, Lima, Peru",
+  "paymentMethod": "DEBIT_CARD",
+  "notes": "Entregar por la tarde",
+  "items": [
+    {
+      "productId": 1,
+      "productName": "Laptop HP",
+      "quantity": 1,
+      "unitPrice": 999.99
+    }
+  ]
+}

--- a/order-service/src/test/resources/mock/orders.json
+++ b/order-service/src/test/resources/mock/orders.json
@@ -1,0 +1,44 @@
+[
+  {
+    "userId": 1,
+    "shippingAddress": "Av. Principal 123, Lima, Peru",
+    "paymentMethod": "CREDIT_CARD",
+    "notes": "Primer pedido",
+    "items": [
+      {
+        "productId": 1,
+        "productName": "Laptop HP",
+        "quantity": 1,
+        "unitPrice": 999.99
+      }
+    ]
+  },
+  {
+    "userId": 1,
+    "shippingAddress": "Av. Secundaria 456, Lima, Peru",
+    "paymentMethod": "DEBIT_CARD",
+    "notes": "Segundo pedido",
+    "items": [
+      {
+        "productId": 2,
+        "productName": "Mouse Logitech",
+        "quantity": 3,
+        "unitPrice": 29.99
+      }
+    ]
+  },
+  {
+    "userId": 2,
+    "shippingAddress": "Jr. Union 789, Arequipa, Peru",
+    "paymentMethod": "CASH",
+    "notes": "Pedido de otro usuario",
+    "items": [
+      {
+        "productId": 3,
+        "productName": "Teclado Mecánico",
+        "quantity": 1,
+        "unitPrice": 149.99
+      }
+    ]
+  }
+]

--- a/order-service/src/test/resources/testcontainers.properties
+++ b/order-service/src/test/resources/testcontainers.properties
@@ -1,0 +1,10 @@
+# TestContainers configuration
+# Configuracion de TestContainers
+
+# Disable Ryuk container reaper
+testcontainers.ryuk.disabled=true
+
+# Disable container reuse
+testcontainers.reuse.enable=false
+
+docker.host=unix:///var/run/docker.sock


### PR DESCRIPTION
## Summary
- Add unit tests for OrderServiceImpl, OrderMapper, OrderController, GlobalExceptionHandler, ApiResponse, and custom exceptions
- Add integration test for OrderRepository using TestContainers with MongoDB 7.0
- Include mock JSON data files and test-specific application profiles (test-nodb, test-tc)

## Test coverage
- **OrderServiceImplTest**: 25 tests covering CRUD, status transitions, validation, and edge cases
- **OrderControllerTest**: 20 tests covering all REST endpoints with MockMvc
- **OrderMapperTest**: 14 tests for entity/DTO/response conversions
- **GlobalExceptionHandlerTest**: 5 tests for all exception handlers
- **ExceptionTest**: 4 tests for custom exception messages
- **ApiResponseTest**: 5 tests for response wrapper
- **OrderRepositoryIntegrationTest**: 15 integration tests with real MongoDB via TestContainers

## Test plan
- [x] Verify unit tests compile without errors
- [x] Run unit tests (mvn test -pl order-service excluding integration)
- [x] Run integration tests with Docker available for TestContainers