### PR TITLE
feat(user-service): add User entity and repository

### DIFF
--- a/config/user-service.yml
+++ b/config/user-service.yml
@@ -1,4 +1,4 @@
-# Configuración para User Service
+# Configuracion para User Service
 # Configuration for User Service
 
 server:
@@ -7,19 +7,21 @@ server:
 spring:
   application:
     name: user-service
-  data:
-    mongodb:
-      host: localhost
-      port: 27017
-      database: userdb
-
-jwt:
-  secret: ${JWT_SECRET:microcommerce-secret-key-change-in-production}
-  expiration: 86400000
+  datasource:
+    url: jdbc:postgresql://localhost:5433/userdb
+    username: postgres
+    password: postgres
+    driver-class-name: org.postgresql.Driver
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: false
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
 
 management:
   endpoints:
     web:
       exposure:
         include: health,info,metrics,prometheus
-

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -38,6 +38,26 @@ services:
     networks:
       - microcommerce-network
 
+  # PostgreSQL for User Service
+  postgres-user:
+    image: postgres:16-alpine
+    container_name: postgres-user
+    environment:
+      POSTGRES_DB: ${USER_POSTGRES_DB:-userdb}
+      POSTGRES_USER: ${USER_POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${USER_POSTGRES_PASSWORD:-postgres}
+    ports:
+      - "5433:5432"
+    volumes:
+      - user-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - microcommerce-network
+
   # MongoDB for Order Service
   mongo-order:
     image: mongo:7-jammy
@@ -73,6 +93,8 @@ services:
 
 volumes:
   product-data:
+    driver: local
+  user-data:
     driver: local
   order-mongo-data:
     driver: local

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
         <module>api-gateway</module>
         <module>product-service</module>
         <module>order-service</module>
+        <module>user-service</module>
     </modules>
 
     <properties>

--- a/user-service/pom.xml
+++ b/user-service/pom.xml
@@ -1,0 +1,184 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+         http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.microcommerce</groupId>
+        <artifactId>microcommerce-parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>user-service</artifactId>
+    <name>User Service</name>
+    <description>User management and authentication service</description>
+
+    <dependencies>
+        <!-- Spring Boot Web -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <!-- Spring Data JPA -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+
+        <!-- PostgreSQL Driver -->
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <!-- Spring Cloud Netflix Eureka Client -->
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
+        </dependency>
+
+        <!-- Spring Cloud Config Client -->
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-config</artifactId>
+        </dependency>
+
+        <!-- Spring Boot Actuator -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+
+        <!-- Validation -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+
+        <!-- Lombok -->
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- Swagger/OpenAPI for API documentation -->
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.3.0</version>
+        </dependency>
+
+        <!-- Spring Boot Test -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- TestContainers -->
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <version>1.19.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>1.19.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>1.19.3</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- AssertJ -->
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                        </exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+
+            <!-- Maven Surefire Plugin - Docker environment for TestContainers -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <environmentVariables>
+                        <DOCKER_HOST>unix:///var/run/docker.sock</DOCKER_HOST>
+                        <TESTCONTAINERS_RYUK_DISABLED>true</TESTCONTAINERS_RYUK_DISABLED>
+                    </environmentVariables>
+                    <systemPropertyVariables>
+                        <api.version>1.41</api.version>
+                        <docker.host>unix:///var/run/docker.sock</docker.host>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+
+            <!-- JaCoCo Maven Plugin for Code Coverage -->
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.11</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>jacoco-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <rule>
+                                    <element>PACKAGE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.80</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/user-service/src/main/java/com/microcommerce/user/UserServiceApplication.java
+++ b/user-service/src/main/java/com/microcommerce/user/UserServiceApplication.java
@@ -1,0 +1,13 @@
+package com.microcommerce.user;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+
+@SpringBootApplication
+@EnableDiscoveryClient
+public class UserServiceApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(UserServiceApplication.class, args);
+    }
+}

--- a/user-service/src/main/java/com/microcommerce/user/config/OpenApiConfig.java
+++ b/user-service/src/main/java/com/microcommerce/user/config/OpenApiConfig.java
@@ -1,0 +1,55 @@
+package com.microcommerce.user.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.License;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+/**
+ * OpenAPI/Swagger configuration
+ * Configuracion de OpenAPI/Swagger
+ */
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI userServiceOpenAPI() {
+        Server localServer = new Server();
+        localServer.setUrl("http://localhost:8083");
+        localServer.setDescription("Servidor de desarrollo local | Local development server");
+
+        Server gatewayServer = new Server();
+        gatewayServer.setUrl("http://localhost:8080/api/users");
+        gatewayServer.setDescription("A traves del API Gateway | Through API Gateway");
+
+        Contact contact = new Contact();
+        contact.setName("MicroCommerce Team");
+        contact.setEmail("contact@microcommerce.com");
+
+        License license = new License()
+                .name("MIT License")
+                .url("https://choosealicense.com/licenses/mit/");
+
+        Info info = new Info()
+                .title("User Service API | API de Servicio de Usuarios")
+                .version("1.0.0")
+                .description("""
+                    API REST para la gestion de usuarios y autenticacion.
+                    Proporciona operaciones CRUD, busqueda y gestion de roles.
+
+                    REST API for user management and authentication.
+                    Provides CRUD operations, search and role management.
+                    """)
+                .contact(contact)
+                .license(license);
+
+        return new OpenAPI()
+                .info(info)
+                .servers(List.of(localServer, gatewayServer));
+    }
+}

--- a/user-service/src/main/java/com/microcommerce/user/dto/UserDTO.java
+++ b/user-service/src/main/java/com/microcommerce/user/dto/UserDTO.java
@@ -1,0 +1,39 @@
+package com.microcommerce.user.dto;
+
+import jakarta.validation.constraints.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Data Transfer Object for User creation and update
+ * Objeto de Transferencia de Datos para creacion y actualizacion de User
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserDTO {
+
+    @NotBlank(message = "El email es requerido")
+    @Email(message = "El formato del email es invalido")
+    @Size(max = 100, message = "El email no debe exceder 100 caracteres")
+    private String email;
+
+    @NotBlank(message = "La contrasena es requerida")
+    @Size(min = 8, max = 100, message = "La contrasena debe tener entre 8 y 100 caracteres")
+    private String password;
+
+    @NotBlank(message = "El nombre es requerido")
+    @Size(min = 2, max = 100, message = "El nombre debe tener entre 2 y 100 caracteres")
+    private String firstName;
+
+    @NotBlank(message = "El apellido es requerido")
+    @Size(min = 2, max = 100, message = "El apellido debe tener entre 2 y 100 caracteres")
+    private String lastName;
+
+    @Size(max = 20, message = "El telefono no debe exceder 20 caracteres")
+    private String phone;
+
+    @Size(max = 500, message = "La direccion no debe exceder 500 caracteres")
+    private String address;
+}

--- a/user-service/src/main/java/com/microcommerce/user/dto/response/ApiResponse.java
+++ b/user-service/src/main/java/com/microcommerce/user/dto/response/ApiResponse.java
@@ -1,0 +1,31 @@
+package com.microcommerce.user.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Generic API response wrapper
+ * Wrapper generico de respuesta API
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ApiResponse<T> {
+
+    private boolean success;
+    private String message;
+    private T data;
+
+    public static <T> ApiResponse<T> success(T data) {
+        return new ApiResponse<>(true, "Operacion exitosa", data);
+    }
+
+    public static <T> ApiResponse<T> success(String message, T data) {
+        return new ApiResponse<>(true, message, data);
+    }
+
+    public static <T> ApiResponse<T> error(String message) {
+        return new ApiResponse<>(false, message, null);
+    }
+}

--- a/user-service/src/main/java/com/microcommerce/user/dto/response/ErrorResponse.java
+++ b/user-service/src/main/java/com/microcommerce/user/dto/response/ErrorResponse.java
@@ -1,0 +1,33 @@
+package com.microcommerce.user.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * Standard error response for API
+ * Respuesta de error estandar para API
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ErrorResponse {
+
+    private LocalDateTime timestamp;
+    private int status;
+    private String error;
+    private String message;
+    private String path;
+    private List<String> details;
+
+    public ErrorResponse(LocalDateTime timestamp, int status, String error, String message, String path) {
+        this.timestamp = timestamp;
+        this.status = status;
+        this.error = error;
+        this.message = message;
+        this.path = path;
+    }
+}

--- a/user-service/src/main/java/com/microcommerce/user/dto/response/UserResponse.java
+++ b/user-service/src/main/java/com/microcommerce/user/dto/response/UserResponse.java
@@ -1,0 +1,31 @@
+package com.microcommerce.user.dto.response;
+
+import com.microcommerce.user.entity.Role;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * User response DTO with complete information (excludes password)
+ * DTO de respuesta de usuario con informacion completa (excluye contrasena)
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserResponse {
+
+    private Long id;
+    private String email;
+    private String firstName;
+    private String lastName;
+    private String phone;
+    private String address;
+    private Role role;
+    private Boolean active;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/user-service/src/main/java/com/microcommerce/user/entity/Role.java
+++ b/user-service/src/main/java/com/microcommerce/user/entity/Role.java
@@ -1,0 +1,11 @@
+package com.microcommerce.user.entity;
+
+/**
+ * Enum representing user roles in the system
+ * Enum que representa los roles de usuario en el sistema
+ */
+public enum Role {
+
+    CUSTOMER,
+    ADMIN
+}

--- a/user-service/src/main/java/com/microcommerce/user/entity/User.java
+++ b/user-service/src/main/java/com/microcommerce/user/entity/User.java
@@ -1,0 +1,63 @@
+package com.microcommerce.user.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+/**
+ * User entity representing a user in the system
+ * Entidad User representando un usuario en el sistema
+ */
+@Entity
+@Table(name = "users")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true, length = 100)
+    private String email;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(name = "first_name", nullable = false, length = 100)
+    private String firstName;
+
+    @Column(name = "last_name", nullable = false, length = 100)
+    private String lastName;
+
+    @Column(length = 20)
+    private String phone;
+
+    @Column(length = 500)
+    private String address;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    @Builder.Default
+    private Role role = Role.CUSTOMER;
+
+    @Column(nullable = false)
+    @Builder.Default
+    private Boolean active = true;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+}

--- a/user-service/src/main/java/com/microcommerce/user/exception/UserAlreadyExistsException.java
+++ b/user-service/src/main/java/com/microcommerce/user/exception/UserAlreadyExistsException.java
@@ -1,0 +1,16 @@
+package com.microcommerce.user.exception;
+
+/**
+ * Exception thrown when attempting to create a user that already exists
+ * Excepcion lanzada cuando se intenta crear un usuario que ya existe
+ */
+public class UserAlreadyExistsException extends RuntimeException {
+
+    public UserAlreadyExistsException(String email) {
+        super("El usuario ya existe con el email: " + email);
+    }
+
+    public UserAlreadyExistsException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/user-service/src/main/java/com/microcommerce/user/exception/UserNotFoundException.java
+++ b/user-service/src/main/java/com/microcommerce/user/exception/UserNotFoundException.java
@@ -1,0 +1,16 @@
+package com.microcommerce.user.exception;
+
+/**
+ * Exception thrown when a user is not found
+ * Excepcion lanzada cuando un usuario no se encuentra
+ */
+public class UserNotFoundException extends RuntimeException {
+
+    public UserNotFoundException(Long id) {
+        super("Usuario no encontrado con id: " + id);
+    }
+
+    public UserNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/user-service/src/main/java/com/microcommerce/user/exception/handler/GlobalExceptionHandler.java
+++ b/user-service/src/main/java/com/microcommerce/user/exception/handler/GlobalExceptionHandler.java
@@ -1,0 +1,87 @@
+package com.microcommerce.user.exception.handler;
+
+import com.microcommerce.user.dto.response.ErrorResponse;
+import com.microcommerce.user.exception.UserAlreadyExistsException;
+import com.microcommerce.user.exception.UserNotFoundException;
+import jakarta.servlet.http.HttpServletRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * Global exception handler for User Service
+ * Manejador global de excepciones para User Service
+ */
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
+
+    @ExceptionHandler(UserNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleUserNotFoundException(
+            UserNotFoundException ex, HttpServletRequest request) {
+        log.error("Usuario no encontrado: {}", ex.getMessage());
+        ErrorResponse errorResponse = new ErrorResponse(
+                LocalDateTime.now(),
+                HttpStatus.NOT_FOUND.value(),
+                "No encontrado",
+                ex.getMessage(),
+                request.getRequestURI()
+        );
+        return new ResponseEntity<>(errorResponse, HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler(UserAlreadyExistsException.class)
+    public ResponseEntity<ErrorResponse> handleUserAlreadyExistsException(
+            UserAlreadyExistsException ex, HttpServletRequest request) {
+        log.error("Usuario ya existe: {}", ex.getMessage());
+        ErrorResponse errorResponse = new ErrorResponse(
+                LocalDateTime.now(),
+                HttpStatus.CONFLICT.value(),
+                "Conflicto",
+                ex.getMessage(),
+                request.getRequestURI()
+        );
+        return new ResponseEntity<>(errorResponse, HttpStatus.CONFLICT);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleValidationException(
+            MethodArgumentNotValidException ex, HttpServletRequest request) {
+        log.error("Error de validacion: {}", ex.getMessage());
+        List<String> details = ex.getBindingResult().getFieldErrors().stream()
+                .map(error -> error.getField() + ": " + error.getDefaultMessage())
+                .toList();
+
+        ErrorResponse errorResponse = new ErrorResponse(
+                LocalDateTime.now(),
+                HttpStatus.BAD_REQUEST.value(),
+                "Error de validacion",
+                "Los datos proporcionados no son validos",
+                request.getRequestURI(),
+                details
+        );
+        return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleGenericException(
+            Exception ex, HttpServletRequest request) {
+        log.error("Error interno del servidor: {}", ex.getMessage(), ex);
+        ErrorResponse errorResponse = new ErrorResponse(
+                LocalDateTime.now(),
+                HttpStatus.INTERNAL_SERVER_ERROR.value(),
+                "Error interno del servidor",
+                "Ha ocurrido un error inesperado",
+                request.getRequestURI()
+        );
+        return new ResponseEntity<>(errorResponse, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+}

--- a/user-service/src/main/java/com/microcommerce/user/mapper/UserMapper.java
+++ b/user-service/src/main/java/com/microcommerce/user/mapper/UserMapper.java
@@ -1,0 +1,107 @@
+package com.microcommerce.user.mapper;
+
+import com.microcommerce.user.dto.UserDTO;
+import com.microcommerce.user.dto.response.UserResponse;
+import com.microcommerce.user.entity.User;
+import org.springframework.stereotype.Component;
+
+/**
+ * Mapper for converting between User entity and DTOs
+ * Mapper para convertir entre entidad User y DTOs
+ */
+@Component
+public class UserMapper {
+
+    /**
+     * Convert UserDTO to User entity
+     * Convertir UserDTO a entidad User
+     */
+    public User toEntity(UserDTO dto) {
+        if (dto == null) {
+            return null;
+        }
+
+        User user = new User();
+        user.setEmail(dto.getEmail());
+        user.setPassword(dto.getPassword());
+        user.setFirstName(dto.getFirstName());
+        user.setLastName(dto.getLastName());
+        user.setPhone(dto.getPhone());
+        user.setAddress(dto.getAddress());
+
+        return user;
+    }
+
+    /**
+     * Update User entity from UserDTO
+     * Actualizar entidad User desde UserDTO
+     */
+    public void updateEntityFromDto(UserDTO dto, User user) {
+        if (dto == null || user == null) {
+            return;
+        }
+
+        if (dto.getEmail() != null) {
+            user.setEmail(dto.getEmail());
+        }
+        if (dto.getPassword() != null) {
+            user.setPassword(dto.getPassword());
+        }
+        if (dto.getFirstName() != null) {
+            user.setFirstName(dto.getFirstName());
+        }
+        if (dto.getLastName() != null) {
+            user.setLastName(dto.getLastName());
+        }
+        if (dto.getPhone() != null) {
+            user.setPhone(dto.getPhone());
+        }
+        if (dto.getAddress() != null) {
+            user.setAddress(dto.getAddress());
+        }
+    }
+
+    /**
+     * Convert User entity to UserDTO
+     * Convertir entidad User a UserDTO
+     */
+    public UserDTO toDto(User user) {
+        if (user == null) {
+            return null;
+        }
+
+        UserDTO dto = new UserDTO();
+        dto.setEmail(user.getEmail());
+        dto.setFirstName(user.getFirstName());
+        dto.setLastName(user.getLastName());
+        dto.setPhone(user.getPhone());
+        dto.setAddress(user.getAddress());
+        // Password is intentionally excluded from DTO conversion
+        // La contrasena se excluye intencionalmente de la conversion a DTO
+
+        return dto;
+    }
+
+    /**
+     * Convert User entity to UserResponse
+     * Convertir entidad User a UserResponse
+     */
+    public UserResponse toResponse(User user) {
+        if (user == null) {
+            return null;
+        }
+
+        return UserResponse.builder()
+                .id(user.getId())
+                .email(user.getEmail())
+                .firstName(user.getFirstName())
+                .lastName(user.getLastName())
+                .phone(user.getPhone())
+                .address(user.getAddress())
+                .role(user.getRole())
+                .active(user.getActive())
+                .createdAt(user.getCreatedAt())
+                .updatedAt(user.getUpdatedAt())
+                .build();
+    }
+}

--- a/user-service/src/main/java/com/microcommerce/user/repository/UserRepository.java
+++ b/user-service/src/main/java/com/microcommerce/user/repository/UserRepository.java
@@ -1,0 +1,81 @@
+package com.microcommerce.user.repository;
+
+import com.microcommerce.user.entity.Role;
+import com.microcommerce.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Repository interface for User entity
+ * Interfaz de repositorio para la entidad User
+ */
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    /**
+     * Find a user by email
+     * Buscar un usuario por email
+     */
+    Optional<User> findByEmail(String email);
+
+    /**
+     * Check if a user exists by email
+     * Verificar si existe un usuario por email
+     */
+    boolean existsByEmail(String email);
+
+    /**
+     * Find users by role
+     * Buscar usuarios por rol
+     */
+    List<User> findByRole(Role role);
+
+    /**
+     * Find active users by role
+     * Buscar usuarios activos por rol
+     */
+    List<User> findByRoleAndActiveTrue(Role role);
+
+    /**
+     * Find all active users
+     * Buscar todos los usuarios activos
+     */
+    List<User> findByActiveTrue();
+
+    /**
+     * Find users by last name containing a search term (case-insensitive)
+     * Buscar usuarios por apellido que contenga un termino de busqueda (sin distincion de mayusculas)
+     */
+    List<User> findByLastNameContainingIgnoreCase(String lastName);
+
+    /**
+     * Find users by first name or last name containing a search term (case-insensitive)
+     * Buscar usuarios por nombre o apellido que contenga un termino de busqueda
+     */
+    @Query("SELECT u FROM User u WHERE LOWER(u.firstName) LIKE LOWER(CONCAT('%', :term, '%')) " +
+           "OR LOWER(u.lastName) LIKE LOWER(CONCAT('%', :term, '%'))")
+    List<User> searchByName(@Param("term") String term);
+
+    /**
+     * Find active user by email
+     * Buscar usuario activo por email
+     */
+    Optional<User> findByEmailAndActiveTrue(String email);
+
+    /**
+     * Count users by role
+     * Contar usuarios por rol
+     */
+    long countByRole(Role role);
+
+    /**
+     * Count active users
+     * Contar usuarios activos
+     */
+    long countByActiveTrue();
+}

--- a/user-service/src/main/resources/application.yml
+++ b/user-service/src/main/resources/application.yml
@@ -1,0 +1,57 @@
+server:
+  port: 8083
+
+spring:
+  application:
+    name: user-service
+  config:
+    import: "optional:configserver:http://localhost:8888"
+  datasource:
+    url: jdbc:postgresql://localhost:5433/userdb
+    username: postgres
+    password: postgres
+    driver-class-name: org.postgresql.Driver
+    hikari:
+      maximum-pool-size: 10
+      minimum-idle: 5
+      connection-timeout: 20000
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+
+eureka:
+  client:
+    service-url:
+      defaultZone: http://localhost:8761/eureka/
+  instance:
+    prefer-ip-address: true
+    instance-id: ${spring.application.name}:${spring.application.instance_id:${random.value}}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,metrics,prometheus
+  endpoint:
+    health:
+      show-details: always
+
+logging:
+  level:
+    com.microcommerce.user: DEBUG
+    org.hibernate.SQL: DEBUG
+    org.hibernate.type.descriptor.sql.BasicBinder: TRACE
+
+springdoc:
+  api-docs:
+    path: /api-docs
+  swagger-ui:
+    path: /swagger-ui.html
+    tags-sorter: alpha
+    operations-sorter: alpha
+  show-actuator: true


### PR DESCRIPTION
## Summary
- Add User Service module with JPA entity (PostgreSQL), repository with custom queries, DTOs, mapper, exception handling, and OpenAPI config
- Add dedicated PostgreSQL container (port 5433) for User Service in docker-compose
- Update Config Server user-service.yml to use PostgreSQL instead of MongoDB
- Register user-service as a module in the parent POM

## Test plan
- [x] Verify `mvn compile -pl user-service -am` succeeds
- [x] Verify Docker Compose starts postgres-user container on port 5433
- [x] Verify User entity creates the `users` table with correct schema via Hibernate ddl-auto
- [x] Verify repository custom queries work against PostgreSQL