### PR TITLE
feat(user-service): add service layer with JWT authentication

### DIFF
--- a/user-service/pom.xml
+++ b/user-service/pom.xml
@@ -66,6 +66,31 @@
             <optional>true</optional>
         </dependency>
 
+        <!-- Spring Security -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+
+        <!-- JWT (JSON Web Token) -->
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-api</artifactId>
+            <version>0.12.3</version>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-impl</artifactId>
+            <version>0.12.3</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-jackson</artifactId>
+            <version>0.12.3</version>
+            <scope>runtime</scope>
+        </dependency>
+
         <!-- Swagger/OpenAPI for API documentation -->
         <dependency>
             <groupId>org.springdoc</groupId>
@@ -77,6 +102,13 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Spring Security Test -->
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/user-service/src/main/java/com/microcommerce/user/config/SecurityConfig.java
+++ b/user-service/src/main/java/com/microcommerce/user/config/SecurityConfig.java
@@ -1,0 +1,64 @@
+package com.microcommerce.user.config;
+
+import com.microcommerce.user.security.JwtAuthenticationEntryPoint;
+import com.microcommerce.user.security.JwtAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+/**
+ * Spring Security configuration with JWT authentication
+ * Configuracion de Spring Security con autenticacion JWT
+ */
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .exceptionHandling(exception -> exception
+                        .authenticationEntryPoint(jwtAuthenticationEntryPoint))
+                .sessionManagement(session -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        // Public endpoints
+                        .requestMatchers("/api/auth/**").permitAll()
+                        // Actuator and documentation
+                        .requestMatchers("/actuator/**").permitAll()
+                        .requestMatchers("/swagger-ui/**", "/api-docs/**", "/swagger-ui.html").permitAll()
+                        // All other requests require authentication
+                        .anyRequest().authenticated())
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(
+            AuthenticationConfiguration authenticationConfiguration) throws Exception {
+        return authenticationConfiguration.getAuthenticationManager();
+    }
+}

--- a/user-service/src/main/java/com/microcommerce/user/dto/request/LoginRequest.java
+++ b/user-service/src/main/java/com/microcommerce/user/dto/request/LoginRequest.java
@@ -1,0 +1,24 @@
+package com.microcommerce.user.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * DTO for user login request
+ * DTO para solicitud de inicio de sesion
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class LoginRequest {
+
+    @NotBlank(message = "El email es requerido")
+    @Email(message = "El formato del email es invalido")
+    private String email;
+
+    @NotBlank(message = "La contrasena es requerida")
+    private String password;
+}

--- a/user-service/src/main/java/com/microcommerce/user/dto/request/RegisterRequest.java
+++ b/user-service/src/main/java/com/microcommerce/user/dto/request/RegisterRequest.java
@@ -1,0 +1,39 @@
+package com.microcommerce.user.dto.request;
+
+import jakarta.validation.constraints.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * DTO for user registration request
+ * DTO para solicitud de registro de usuario
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class RegisterRequest {
+
+    @NotBlank(message = "El email es requerido")
+    @Email(message = "El formato del email es invalido")
+    @Size(max = 100, message = "El email no debe exceder 100 caracteres")
+    private String email;
+
+    @NotBlank(message = "La contrasena es requerida")
+    @Size(min = 8, max = 100, message = "La contrasena debe tener entre 8 y 100 caracteres")
+    private String password;
+
+    @NotBlank(message = "El nombre es requerido")
+    @Size(min = 2, max = 100, message = "El nombre debe tener entre 2 y 100 caracteres")
+    private String firstName;
+
+    @NotBlank(message = "El apellido es requerido")
+    @Size(min = 2, max = 100, message = "El apellido debe tener entre 2 y 100 caracteres")
+    private String lastName;
+
+    @Size(max = 20, message = "El telefono no debe exceder 20 caracteres")
+    private String phone;
+
+    @Size(max = 500, message = "La direccion no debe exceder 500 caracteres")
+    private String address;
+}

--- a/user-service/src/main/java/com/microcommerce/user/dto/response/AuthResponse.java
+++ b/user-service/src/main/java/com/microcommerce/user/dto/response/AuthResponse.java
@@ -1,0 +1,33 @@
+package com.microcommerce.user.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * DTO for authentication response containing JWT token
+ * DTO para respuesta de autenticacion conteniendo token JWT
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AuthResponse {
+
+    private String token;
+    private String type;
+    private Long userId;
+    private String email;
+    private String role;
+
+    public static AuthResponse of(String token, Long userId, String email, String role) {
+        return AuthResponse.builder()
+                .token(token)
+                .type("Bearer")
+                .userId(userId)
+                .email(email)
+                .role(role)
+                .build();
+    }
+}

--- a/user-service/src/main/java/com/microcommerce/user/exception/InvalidCredentialsException.java
+++ b/user-service/src/main/java/com/microcommerce/user/exception/InvalidCredentialsException.java
@@ -1,0 +1,16 @@
+package com.microcommerce.user.exception;
+
+/**
+ * Exception thrown when authentication credentials are invalid
+ * Excepcion lanzada cuando las credenciales de autenticacion son invalidas
+ */
+public class InvalidCredentialsException extends RuntimeException {
+
+    public InvalidCredentialsException() {
+        super("Credenciales invalidas");
+    }
+
+    public InvalidCredentialsException(String message) {
+        super(message);
+    }
+}

--- a/user-service/src/main/java/com/microcommerce/user/exception/UserDisabledException.java
+++ b/user-service/src/main/java/com/microcommerce/user/exception/UserDisabledException.java
@@ -1,0 +1,12 @@
+package com.microcommerce.user.exception;
+
+/**
+ * Exception thrown when a disabled user attempts to authenticate
+ * Excepcion lanzada cuando un usuario deshabilitado intenta autenticarse
+ */
+public class UserDisabledException extends RuntimeException {
+
+    public UserDisabledException(String email) {
+        super("La cuenta del usuario esta deshabilitada: " + email);
+    }
+}

--- a/user-service/src/main/java/com/microcommerce/user/exception/handler/GlobalExceptionHandler.java
+++ b/user-service/src/main/java/com/microcommerce/user/exception/handler/GlobalExceptionHandler.java
@@ -1,7 +1,9 @@
 package com.microcommerce.user.exception.handler;
 
 import com.microcommerce.user.dto.response.ErrorResponse;
+import com.microcommerce.user.exception.InvalidCredentialsException;
 import com.microcommerce.user.exception.UserAlreadyExistsException;
+import com.microcommerce.user.exception.UserDisabledException;
 import com.microcommerce.user.exception.UserNotFoundException;
 import jakarta.servlet.http.HttpServletRequest;
 import org.slf4j.Logger;
@@ -50,6 +52,34 @@ public class GlobalExceptionHandler {
                 request.getRequestURI()
         );
         return new ResponseEntity<>(errorResponse, HttpStatus.CONFLICT);
+    }
+
+    @ExceptionHandler(InvalidCredentialsException.class)
+    public ResponseEntity<ErrorResponse> handleInvalidCredentialsException(
+            InvalidCredentialsException ex, HttpServletRequest request) {
+        log.error("Credenciales invalidas: {}", ex.getMessage());
+        ErrorResponse errorResponse = new ErrorResponse(
+                LocalDateTime.now(),
+                HttpStatus.UNAUTHORIZED.value(),
+                "No autorizado",
+                ex.getMessage(),
+                request.getRequestURI()
+        );
+        return new ResponseEntity<>(errorResponse, HttpStatus.UNAUTHORIZED);
+    }
+
+    @ExceptionHandler(UserDisabledException.class)
+    public ResponseEntity<ErrorResponse> handleUserDisabledException(
+            UserDisabledException ex, HttpServletRequest request) {
+        log.error("Usuario deshabilitado: {}", ex.getMessage());
+        ErrorResponse errorResponse = new ErrorResponse(
+                LocalDateTime.now(),
+                HttpStatus.FORBIDDEN.value(),
+                "Prohibido",
+                ex.getMessage(),
+                request.getRequestURI()
+        );
+        return new ResponseEntity<>(errorResponse, HttpStatus.FORBIDDEN);
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)

--- a/user-service/src/main/java/com/microcommerce/user/mapper/UserMapper.java
+++ b/user-service/src/main/java/com/microcommerce/user/mapper/UserMapper.java
@@ -44,9 +44,8 @@ public class UserMapper {
         if (dto.getEmail() != null) {
             user.setEmail(dto.getEmail());
         }
-        if (dto.getPassword() != null) {
-            user.setPassword(dto.getPassword());
-        }
+        // Password is handled by the service layer (encoded with BCrypt)
+        // La contrasena se maneja en la capa de servicio (codificada con BCrypt)
         if (dto.getFirstName() != null) {
             user.setFirstName(dto.getFirstName());
         }

--- a/user-service/src/main/java/com/microcommerce/user/security/JwtAuthenticationEntryPoint.java
+++ b/user-service/src/main/java/com/microcommerce/user/security/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,47 @@
+package com.microcommerce.user.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.microcommerce.user.dto.response.ErrorResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+
+/**
+ * Entry point for handling unauthorized access attempts
+ * Punto de entrada para manejar intentos de acceso no autorizados
+ */
+@Component
+@Slf4j
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void commence(HttpServletRequest request,
+                         HttpServletResponse response,
+                         AuthenticationException authException) throws IOException {
+
+        log.error("Acceso no autorizado: {}", authException.getMessage());
+
+        ErrorResponse errorResponse = new ErrorResponse(
+                LocalDateTime.now(),
+                HttpStatus.UNAUTHORIZED.value(),
+                "No autorizado",
+                "Se requiere autenticacion para acceder a este recurso",
+                request.getRequestURI()
+        );
+
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        objectMapper.findAndRegisterModules();
+        objectMapper.writeValue(response.getOutputStream(), errorResponse);
+    }
+}

--- a/user-service/src/main/java/com/microcommerce/user/security/JwtAuthenticationFilter.java
+++ b/user-service/src/main/java/com/microcommerce/user/security/JwtAuthenticationFilter.java
@@ -1,0 +1,71 @@
+package com.microcommerce.user.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * JWT authentication filter that intercepts requests and validates tokens
+ * Filtro de autenticacion JWT que intercepta solicitudes y valida tokens
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+
+        String token = extractTokenFromRequest(request);
+
+        if (StringUtils.hasText(token) && jwtTokenProvider.validateToken(token)) {
+            String email = jwtTokenProvider.getEmailFromToken(token);
+            String role = jwtTokenProvider.getRoleFromToken(token);
+
+            List<SimpleGrantedAuthority> authorities = List.of(
+                    new SimpleGrantedAuthority("ROLE_" + role)
+            );
+
+            UsernamePasswordAuthenticationToken authentication =
+                    new UsernamePasswordAuthenticationToken(email, null, authorities);
+            authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+            log.debug("Autenticacion establecida para usuario: {}", email);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    /**
+     * Extract JWT token from Authorization header
+     * Extraer token JWT del encabezado Authorization
+     */
+    private String extractTokenFromRequest(HttpServletRequest request) {
+        String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
+            return bearerToken.substring(BEARER_PREFIX.length());
+        }
+        return null;
+    }
+}

--- a/user-service/src/main/java/com/microcommerce/user/security/JwtTokenProvider.java
+++ b/user-service/src/main/java/com/microcommerce/user/security/JwtTokenProvider.java
@@ -1,0 +1,107 @@
+package com.microcommerce.user.security;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.util.Base64;
+import java.util.Date;
+
+/**
+ * Utility component for JWT token generation and validation
+ * Componente utilitario para generacion y validacion de tokens JWT
+ */
+@Component
+@Slf4j
+public class JwtTokenProvider {
+
+    private final SecretKey secretKey;
+    private final long expiration;
+
+    public JwtTokenProvider(
+            @Value("${jwt.secret}") String secret,
+            @Value("${jwt.expiration}") long expiration) {
+        byte[] keyBytes = Base64.getDecoder().decode(secret);
+        this.secretKey = Keys.hmacShaKeyFor(keyBytes);
+        this.expiration = expiration;
+    }
+
+    /**
+     * Generate JWT token for a user
+     * Generar token JWT para un usuario
+     */
+    public String generateToken(Long userId, String email, String role) {
+        Date now = new Date();
+        Date expiryDate = new Date(now.getTime() + expiration);
+
+        return Jwts.builder()
+                .subject(email)
+                .claim("userId", userId)
+                .claim("role", role)
+                .issuedAt(now)
+                .expiration(expiryDate)
+                .signWith(secretKey)
+                .compact();
+    }
+
+    /**
+     * Extract email (subject) from JWT token
+     * Extraer email (subject) del token JWT
+     */
+    public String getEmailFromToken(String token) {
+        return parseClaims(token).getSubject();
+    }
+
+    /**
+     * Extract user ID from JWT token
+     * Extraer ID de usuario del token JWT
+     */
+    public Long getUserIdFromToken(String token) {
+        return parseClaims(token).get("userId", Long.class);
+    }
+
+    /**
+     * Extract role from JWT token
+     * Extraer rol del token JWT
+     */
+    public String getRoleFromToken(String token) {
+        return parseClaims(token).get("role", String.class);
+    }
+
+    /**
+     * Validate JWT token
+     * Validar token JWT
+     */
+    public boolean validateToken(String token) {
+        try {
+            parseClaims(token);
+            return true;
+        } catch (ExpiredJwtException ex) {
+            log.error("Token JWT expirado: {}", ex.getMessage());
+        } catch (MalformedJwtException ex) {
+            log.error("Token JWT malformado: {}", ex.getMessage());
+        } catch (UnsupportedJwtException ex) {
+            log.error("Token JWT no soportado: {}", ex.getMessage());
+        } catch (IllegalArgumentException ex) {
+            log.error("Token JWT vacio o nulo: {}", ex.getMessage());
+        } catch (JwtException ex) {
+            log.error("Error al validar token JWT: {}", ex.getMessage());
+        }
+        return false;
+    }
+
+    /**
+     * Parse claims from JWT token
+     * Parsear claims del token JWT
+     */
+    private Claims parseClaims(String token) {
+        return Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+}

--- a/user-service/src/main/java/com/microcommerce/user/service/UserService.java
+++ b/user-service/src/main/java/com/microcommerce/user/service/UserService.java
@@ -1,0 +1,101 @@
+package com.microcommerce.user.service;
+
+import com.microcommerce.user.dto.UserDTO;
+import com.microcommerce.user.dto.request.LoginRequest;
+import com.microcommerce.user.dto.request.RegisterRequest;
+import com.microcommerce.user.dto.response.AuthResponse;
+import com.microcommerce.user.entity.Role;
+import com.microcommerce.user.entity.User;
+
+import java.util.List;
+
+/**
+ * Service interface for User operations and authentication
+ * Interfaz de servicio para operaciones de usuario y autenticacion
+ */
+public interface UserService {
+
+    // ==================== Authentication ====================
+
+    /**
+     * Register a new user
+     * Registrar un nuevo usuario
+     */
+    AuthResponse register(RegisterRequest request);
+
+    /**
+     * Authenticate user and return JWT token
+     * Autenticar usuario y devolver token JWT
+     */
+    AuthResponse login(LoginRequest request);
+
+    // ==================== CRUD Operations ====================
+
+    /**
+     * Get user by ID
+     * Obtener usuario por ID
+     */
+    User getUserById(Long id);
+
+    /**
+     * Get user by email
+     * Obtener usuario por email
+     */
+    User getUserByEmail(String email);
+
+    /**
+     * Get all users
+     * Obtener todos los usuarios
+     */
+    List<User> getAllUsers();
+
+    /**
+     * Get all active users
+     * Obtener todos los usuarios activos
+     */
+    List<User> getActiveUsers();
+
+    /**
+     * Update user profile
+     * Actualizar perfil de usuario
+     */
+    User updateUser(Long id, UserDTO dto);
+
+    /**
+     * Deactivate user (soft delete)
+     * Desactivar usuario (eliminacion logica)
+     */
+    void deactivateUser(Long id);
+
+    // ==================== Query Operations ====================
+
+    /**
+     * Search users by name
+     * Buscar usuarios por nombre
+     */
+    List<User> searchByName(String term);
+
+    /**
+     * Get users by role
+     * Obtener usuarios por rol
+     */
+    List<User> getUsersByRole(Role role);
+
+    /**
+     * Get active users by role
+     * Obtener usuarios activos por rol
+     */
+    List<User> getActiveUsersByRole(Role role);
+
+    /**
+     * Count users by role
+     * Contar usuarios por rol
+     */
+    long countByRole(Role role);
+
+    /**
+     * Count active users
+     * Contar usuarios activos
+     */
+    long countActiveUsers();
+}

--- a/user-service/src/main/java/com/microcommerce/user/service/UserServiceImpl.java
+++ b/user-service/src/main/java/com/microcommerce/user/service/UserServiceImpl.java
@@ -1,0 +1,201 @@
+package com.microcommerce.user.service;
+
+import com.microcommerce.user.dto.UserDTO;
+import com.microcommerce.user.dto.request.LoginRequest;
+import com.microcommerce.user.dto.request.RegisterRequest;
+import com.microcommerce.user.dto.response.AuthResponse;
+import com.microcommerce.user.entity.Role;
+import com.microcommerce.user.entity.User;
+import com.microcommerce.user.exception.InvalidCredentialsException;
+import com.microcommerce.user.exception.UserAlreadyExistsException;
+import com.microcommerce.user.exception.UserDisabledException;
+import com.microcommerce.user.exception.UserNotFoundException;
+import com.microcommerce.user.mapper.UserMapper;
+import com.microcommerce.user.repository.UserRepository;
+import com.microcommerce.user.security.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * Implementation of UserService with JWT authentication
+ * Implementacion de UserService con autenticacion JWT
+ */
+@Service
+@Transactional
+@RequiredArgsConstructor
+@Slf4j
+public class UserServiceImpl implements UserService {
+
+    private final UserRepository userRepository;
+    private final UserMapper userMapper;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    // ==================== Authentication ====================
+
+    @Override
+    public AuthResponse register(RegisterRequest request) {
+        log.info("Registrando nuevo usuario: {}", request.getEmail());
+
+        if (userRepository.existsByEmail(request.getEmail())) {
+            throw new UserAlreadyExistsException(request.getEmail());
+        }
+
+        User user = User.builder()
+                .email(request.getEmail())
+                .password(passwordEncoder.encode(request.getPassword()))
+                .firstName(request.getFirstName())
+                .lastName(request.getLastName())
+                .phone(request.getPhone())
+                .address(request.getAddress())
+                .role(Role.CUSTOMER)
+                .active(true)
+                .build();
+
+        User savedUser = userRepository.save(user);
+
+        String token = jwtTokenProvider.generateToken(
+                savedUser.getId(),
+                savedUser.getEmail(),
+                savedUser.getRole().name()
+        );
+
+        log.info("Usuario registrado satisfactoriamente: {}", savedUser.getEmail());
+        return AuthResponse.of(token, savedUser.getId(), savedUser.getEmail(), savedUser.getRole().name());
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public AuthResponse login(LoginRequest request) {
+        log.info("Intento de inicio de sesion: {}", request.getEmail());
+
+        User user = userRepository.findByEmail(request.getEmail())
+                .orElseThrow(InvalidCredentialsException::new);
+
+        if (!user.getActive()) {
+            throw new UserDisabledException(user.getEmail());
+        }
+
+        if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
+            throw new InvalidCredentialsException();
+        }
+
+        String token = jwtTokenProvider.generateToken(
+                user.getId(),
+                user.getEmail(),
+                user.getRole().name()
+        );
+
+        log.info("Inicio de sesion exitoso: {}", user.getEmail());
+        return AuthResponse.of(token, user.getId(), user.getEmail(), user.getRole().name());
+    }
+
+    // ==================== CRUD Operations ====================
+
+    @Override
+    @Transactional(readOnly = true)
+    public User getUserById(Long id) {
+        log.debug("Obteniendo usuario con ID: {}", id);
+        return userRepository.findById(id)
+                .orElseThrow(() -> new UserNotFoundException(id));
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public User getUserByEmail(String email) {
+        log.debug("Obteniendo usuario con email: {}", email);
+        return userRepository.findByEmail(email)
+                .orElseThrow(() -> new UserNotFoundException("Usuario no encontrado con email: " + email));
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<User> getAllUsers() {
+        log.debug("Obteniendo todos los usuarios");
+        return userRepository.findAll();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<User> getActiveUsers() {
+        log.debug("Obteniendo todos los usuarios activos");
+        return userRepository.findByActiveTrue();
+    }
+
+    @Override
+    public User updateUser(Long id, UserDTO dto) {
+        log.info("Actualizando usuario con ID: {}", id);
+
+        User user = getUserById(id);
+
+        // Check if email is being changed and is already taken
+        if (dto.getEmail() != null && !dto.getEmail().equals(user.getEmail())
+                && userRepository.existsByEmail(dto.getEmail())) {
+            throw new UserAlreadyExistsException(dto.getEmail());
+        }
+
+        userMapper.updateEntityFromDto(dto, user);
+
+        // Encode password if it was updated
+        if (dto.getPassword() != null) {
+            user.setPassword(passwordEncoder.encode(dto.getPassword()));
+        }
+
+        User updatedUser = userRepository.save(user);
+        log.info("Usuario actualizado satisfactoriamente: {}", id);
+        return updatedUser;
+    }
+
+    @Override
+    public void deactivateUser(Long id) {
+        log.info("Desactivando usuario con ID: {}", id);
+
+        User user = getUserById(id);
+        user.setActive(false);
+        userRepository.save(user);
+
+        log.info("Usuario desactivado satisfactoriamente: {}", id);
+    }
+
+    // ==================== Query Operations ====================
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<User> searchByName(String term) {
+        log.debug("Buscando usuarios por nombre: {}", term);
+        return userRepository.searchByName(term);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<User> getUsersByRole(Role role) {
+        log.debug("Obteniendo usuarios por rol: {}", role);
+        return userRepository.findByRole(role);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<User> getActiveUsersByRole(Role role) {
+        log.debug("Obteniendo usuarios activos por rol: {}", role);
+        return userRepository.findByRoleAndActiveTrue(role);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public long countByRole(Role role) {
+        log.debug("Contando usuarios por rol: {}", role);
+        return userRepository.countByRole(role);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public long countActiveUsers() {
+        log.debug("Contando usuarios activos");
+        return userRepository.countByActiveTrue();
+    }
+}

--- a/user-service/src/main/resources/application.yml
+++ b/user-service/src/main/resources/application.yml
@@ -41,6 +41,10 @@ management:
     health:
       show-details: always
 
+jwt:
+  secret: ${JWT_SECRET:bWljcm9jb21tZXJjZS1zZWNyZXQta2V5LWZvci1kZXZlbG9wbWVudC1vbmx5LWNoYW5nZS1pbi1wcm9kdWN0aW9u}
+  expiration: ${JWT_EXPIRATION:86400000}
+
 logging:
   level:
     com.microcommerce.user: DEBUG


### PR DESCRIPTION
## Summary
- Add UserService interface and UserServiceImpl with registration, login (JWT), and full CRUD/query operations
- Implement Spring Security configuration with stateless JWT authentication, BCrypt password encoding, and public/protected endpoint rules
- Add JwtTokenProvider, JwtAuthenticationFilter, JwtAuthenticationEntryPoint, auth DTOs (LoginRequest, RegisterRequest, AuthResponse), and custom exceptions (InvalidCredentialsException, UserDisabledException)

## Test plan
- [x] Verify user registration returns JWT token
- [x] Verify login with valid credentials returns JWT token
- [x] Verify login with invalid credentials returns 401
- [x] Verify disabled user cannot authenticate (403)
- [x] Verify duplicate email registration returns 409
- [x] Verify protected endpoints require valid JWT
- [x] Verify public endpoints (/api/auth/**, actuator, swagger) are accessible without token
- [x] Verify password is encoded with BCrypt on registration and update