### PR TITLE
test(payment-service): add unit and integration tests for Payment Service

### DIFF
--- a/payment-service/src/test/java/com/microcommerce/payment/dto/response/ApiResponseTest.java
+++ b/payment-service/src/test/java/com/microcommerce/payment/dto/response/ApiResponseTest.java
@@ -1,0 +1,58 @@
+package com.microcommerce.payment.dto.response;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.*;
+
+/**
+ * Unit tests for ApiResponse
+ * Tests unitarios para ApiResponse
+ */
+@DisplayName("ApiResponse Tests")
+class ApiResponseTest {
+
+    @Test
+    @DisplayName("success con data - debe retornar success true con data y mensaje por defecto")
+    void success_WithData_ReturnsSuccessTrueWithDefaultMessage() {
+        // Given
+        String data = "test data";
+
+        // When
+        ApiResponse<String> response = ApiResponse.success(data);
+
+        // Then
+        assertThat(response.isSuccess()).isTrue();
+        assertThat(response.getMessage()).isEqualTo("Operacion exitosa");
+        assertThat(response.getData()).isEqualTo("test data");
+    }
+
+    @Test
+    @DisplayName("success con mensaje y data - debe retornar success true con mensaje personalizado")
+    void success_WithMessageAndData_ReturnsSuccessTrueWithCustomMessage() {
+        // Given
+        String message = "Pago procesado correctamente";
+        PaymentResponse data = PaymentResponse.builder().id(1L).build();
+
+        // When
+        ApiResponse<PaymentResponse> response = ApiResponse.success(message, data);
+
+        // Then
+        assertThat(response.isSuccess()).isTrue();
+        assertThat(response.getMessage()).isEqualTo("Pago procesado correctamente");
+        assertThat(response.getData()).isNotNull();
+        assertThat(response.getData().getId()).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("error con mensaje - debe retornar success false con data null")
+    void error_WithMessage_ReturnsSuccessFalseWithNullData() {
+        // When
+        ApiResponse<Object> response = ApiResponse.error("Error al procesar pago");
+
+        // Then
+        assertThat(response.isSuccess()).isFalse();
+        assertThat(response.getMessage()).isEqualTo("Error al procesar pago");
+        assertThat(response.getData()).isNull();
+    }
+}

--- a/payment-service/src/test/java/com/microcommerce/payment/dto/response/StripeResponseTest.java
+++ b/payment-service/src/test/java/com/microcommerce/payment/dto/response/StripeResponseTest.java
@@ -1,0 +1,113 @@
+package com.microcommerce.payment.dto.response;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.*;
+
+/**
+ * Unit tests for Stripe response DTOs
+ * Tests unitarios para DTOs de respuesta de Stripe
+ */
+@DisplayName("Stripe Response DTO Tests")
+class StripeResponseTest {
+
+    // ==================== StripePaymentIntentResponse Tests ====================
+
+    @Test
+    @DisplayName("isSucceeded - status succeeded - debe retornar true")
+    void stripePaymentIntent_StatusSucceeded_IsSucceededReturnsTrue() {
+        // Given
+        StripePaymentIntentResponse response = StripePaymentIntentResponse.builder()
+                .id("pi_test_001")
+                .status("succeeded")
+                .build();
+
+        // When & Then
+        assertThat(response.isSucceeded()).isTrue();
+        assertThat(response.requiresAction()).isFalse();
+    }
+
+    @Test
+    @DisplayName("requiresAction - status requires_action - debe retornar true")
+    void stripePaymentIntent_StatusRequiresAction_RequiresActionReturnsTrue() {
+        // Given
+        StripePaymentIntentResponse response = StripePaymentIntentResponse.builder()
+                .id("pi_test_002")
+                .status("requires_action")
+                .build();
+
+        // When & Then
+        assertThat(response.requiresAction()).isTrue();
+        assertThat(response.isSucceeded()).isFalse();
+    }
+
+    @Test
+    @DisplayName("isSucceeded - status diferente - debe retornar false")
+    void stripePaymentIntent_DifferentStatus_IsSucceededReturnsFalse() {
+        // Given
+        StripePaymentIntentResponse response = StripePaymentIntentResponse.builder()
+                .id("pi_test_003")
+                .status("canceled")
+                .build();
+
+        // When & Then
+        assertThat(response.isSucceeded()).isFalse();
+        assertThat(response.requiresAction()).isFalse();
+    }
+
+    @Test
+    @DisplayName("isSucceeded - status null - debe retornar false")
+    void stripePaymentIntent_NullStatus_IsSucceededReturnsFalse() {
+        // Given
+        StripePaymentIntentResponse response = StripePaymentIntentResponse.builder()
+                .id("pi_test_004")
+                .status(null)
+                .build();
+
+        // When & Then
+        assertThat(response.isSucceeded()).isFalse();
+        assertThat(response.requiresAction()).isFalse();
+    }
+
+    // ==================== StripeRefundResponse Tests ====================
+
+    @Test
+    @DisplayName("StripeRefundResponse isSucceeded - status succeeded - debe retornar true")
+    void stripeRefund_StatusSucceeded_IsSucceededReturnsTrue() {
+        // Given
+        StripeRefundResponse response = StripeRefundResponse.builder()
+                .id("re_test_001")
+                .status("succeeded")
+                .build();
+
+        // When & Then
+        assertThat(response.isSucceeded()).isTrue();
+    }
+
+    @Test
+    @DisplayName("StripeRefundResponse isSucceeded - status pending - debe retornar false")
+    void stripeRefund_StatusPending_IsSucceededReturnsFalse() {
+        // Given
+        StripeRefundResponse response = StripeRefundResponse.builder()
+                .id("re_test_002")
+                .status("pending")
+                .build();
+
+        // When & Then
+        assertThat(response.isSucceeded()).isFalse();
+    }
+
+    @Test
+    @DisplayName("StripeRefundResponse isSucceeded - status null - debe retornar false")
+    void stripeRefund_NullStatus_IsSucceededReturnsFalse() {
+        // Given
+        StripeRefundResponse response = StripeRefundResponse.builder()
+                .id("re_test_003")
+                .status(null)
+                .build();
+
+        // When & Then
+        assertThat(response.isSucceeded()).isFalse();
+    }
+}

--- a/payment-service/src/test/java/com/microcommerce/payment/exception/ExceptionTest.java
+++ b/payment-service/src/test/java/com/microcommerce/payment/exception/ExceptionTest.java
@@ -1,0 +1,102 @@
+package com.microcommerce.payment.exception;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.*;
+
+/**
+ * Unit tests for Payment Service custom exceptions
+ * Tests unitarios para excepciones personalizadas de Payment Service
+ */
+@DisplayName("Exception Tests")
+class ExceptionTest {
+
+    // ==================== PaymentNotFoundException Tests ====================
+
+    @Test
+    @DisplayName("PaymentNotFoundException - con mensaje - debe contener mensaje correcto")
+    void paymentNotFoundException_WithMessage_ContainsCorrectMessage() {
+        // When
+        PaymentNotFoundException exception = new PaymentNotFoundException("Pago no encontrado");
+
+        // Then
+        assertThat(exception.getMessage()).isEqualTo("Pago no encontrado");
+    }
+
+    @Test
+    @DisplayName("PaymentNotFoundException - con ID - debe contener ID en mensaje")
+    void paymentNotFoundException_WithId_ContainsIdInMessage() {
+        // When
+        PaymentNotFoundException exception = new PaymentNotFoundException(42L);
+
+        // Then
+        assertThat(exception.getMessage()).contains("42");
+    }
+
+    // ==================== PaymentAlreadyProcessedException Tests ====================
+
+    @Test
+    @DisplayName("PaymentAlreadyProcessedException - con mensaje - debe contener mensaje correcto")
+    void paymentAlreadyProcessedException_WithMessage_ContainsCorrectMessage() {
+        // When
+        PaymentAlreadyProcessedException exception =
+                new PaymentAlreadyProcessedException("Pago duplicado");
+
+        // Then
+        assertThat(exception.getMessage()).isEqualTo("Pago duplicado");
+    }
+
+    @Test
+    @DisplayName("PaymentAlreadyProcessedException - con orderId - debe contener orderId en mensaje")
+    void paymentAlreadyProcessedException_WithOrderId_ContainsOrderIdInMessage() {
+        // When
+        PaymentAlreadyProcessedException exception =
+                new PaymentAlreadyProcessedException(100L);
+
+        // Then
+        assertThat(exception.getMessage()).contains("100");
+    }
+
+    // ==================== InvalidPaymentStateException Tests ====================
+
+    @Test
+    @DisplayName("InvalidPaymentStateException - con mensaje - debe contener mensaje correcto")
+    void invalidPaymentStateException_WithMessage_ContainsCorrectMessage() {
+        // When
+        InvalidPaymentStateException exception =
+                new InvalidPaymentStateException("Estado invalido para operacion");
+
+        // Then
+        assertThat(exception.getMessage()).isEqualTo("Estado invalido para operacion");
+    }
+
+    // ==================== PaymentGatewayException Tests ====================
+
+    @Test
+    @DisplayName("PaymentGatewayException - con mensaje - debe contener mensaje correcto")
+    void paymentGatewayException_WithMessage_ContainsCorrectMessage() {
+        // When
+        PaymentGatewayException exception =
+                new PaymentGatewayException("Error en Stripe");
+
+        // Then
+        assertThat(exception.getMessage()).isEqualTo("Error en Stripe");
+    }
+
+    @Test
+    @DisplayName("PaymentGatewayException - con causa - debe contener causa correcta")
+    void paymentGatewayException_WithCause_ContainsCorrectCause() {
+        // Given
+        RuntimeException cause = new RuntimeException("Connection timeout");
+
+        // When
+        PaymentGatewayException exception =
+                new PaymentGatewayException("Error en Stripe", cause);
+
+        // Then
+        assertThat(exception.getMessage()).isEqualTo("Error en Stripe");
+        assertThat(exception.getCause()).isEqualTo(cause);
+        assertThat(exception.getCause().getMessage()).isEqualTo("Connection timeout");
+    }
+}

--- a/payment-service/src/test/java/com/microcommerce/payment/exception/handler/GlobalExceptionHandlerTest.java
+++ b/payment-service/src/test/java/com/microcommerce/payment/exception/handler/GlobalExceptionHandlerTest.java
@@ -1,0 +1,161 @@
+package com.microcommerce.payment.exception.handler;
+
+import com.microcommerce.payment.dto.response.ErrorResponse;
+import com.microcommerce.payment.exception.InvalidPaymentStateException;
+import com.microcommerce.payment.exception.PaymentAlreadyProcessedException;
+import com.microcommerce.payment.exception.PaymentGatewayException;
+import com.microcommerce.payment.exception.PaymentNotFoundException;
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for GlobalExceptionHandler
+ * Tests unitarios para GlobalExceptionHandler
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GlobalExceptionHandler Tests")
+class GlobalExceptionHandlerTest {
+
+    @InjectMocks
+    private GlobalExceptionHandler globalExceptionHandler;
+
+    @Mock
+    private HttpServletRequest request;
+
+    @BeforeEach
+    void setUp() {
+        when(request.getRequestURI()).thenReturn("/api/payments");
+    }
+
+    @Test
+    @DisplayName("handlePaymentNotFoundException - debe retornar 404 NOT_FOUND")
+    void handlePaymentNotFoundException_Returns404() {
+        // Given
+        PaymentNotFoundException ex = new PaymentNotFoundException(1L);
+
+        // When
+        ResponseEntity<ErrorResponse> response =
+                globalExceptionHandler.handlePaymentNotFoundException(ex, request);
+
+        // Then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getStatus()).isEqualTo(404);
+        assertThat(response.getBody().getMessage()).contains("1");
+        assertThat(response.getBody().getPath()).isEqualTo("/api/payments");
+    }
+
+    @Test
+    @DisplayName("handlePaymentAlreadyProcessedException - debe retornar 409 CONFLICT")
+    void handlePaymentAlreadyProcessedException_Returns409() {
+        // Given
+        PaymentAlreadyProcessedException ex = new PaymentAlreadyProcessedException(100L);
+
+        // When
+        ResponseEntity<ErrorResponse> response =
+                globalExceptionHandler.handlePaymentAlreadyProcessedException(ex, request);
+
+        // Then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getStatus()).isEqualTo(409);
+        assertThat(response.getBody().getMessage()).contains("100");
+    }
+
+    @Test
+    @DisplayName("handleInvalidPaymentStateException - debe retornar 400 BAD_REQUEST")
+    void handleInvalidPaymentStateException_Returns400() {
+        // Given
+        InvalidPaymentStateException ex =
+                new InvalidPaymentStateException("Estado invalido para cancelacion");
+
+        // When
+        ResponseEntity<ErrorResponse> response =
+                globalExceptionHandler.handleInvalidPaymentStateException(ex, request);
+
+        // Then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getStatus()).isEqualTo(400);
+        assertThat(response.getBody().getMessage()).contains("Estado invalido");
+    }
+
+    @Test
+    @DisplayName("handlePaymentGatewayException - debe retornar 503 SERVICE_UNAVAILABLE")
+    void handlePaymentGatewayException_Returns503() {
+        // Given
+        PaymentGatewayException ex =
+                new PaymentGatewayException("Error de conexion con Stripe");
+
+        // When
+        ResponseEntity<ErrorResponse> response =
+                globalExceptionHandler.handlePaymentGatewayException(ex, request);
+
+        // Then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getStatus()).isEqualTo(503);
+        assertThat(response.getBody().getMessage()).contains("Stripe");
+    }
+
+    @Test
+    @DisplayName("handleValidationException - debe retornar 400 con detalles de validacion")
+    void handleValidationException_Returns400WithDetails() {
+        // Given
+        BindingResult bindingResult = mock(BindingResult.class);
+        FieldError fieldError1 = new FieldError("paymentRequest", "amount",
+                "El monto es obligatorio");
+        FieldError fieldError2 = new FieldError("paymentRequest", "orderId",
+                "El ID de la orden es obligatorio");
+
+        when(bindingResult.getFieldErrors()).thenReturn(List.of(fieldError1, fieldError2));
+
+        MethodArgumentNotValidException ex =
+                new MethodArgumentNotValidException(null, bindingResult);
+
+        // When
+        ResponseEntity<ErrorResponse> response =
+                globalExceptionHandler.handleValidationException(ex, request);
+
+        // Then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getStatus()).isEqualTo(400);
+        assertThat(response.getBody().getDetails()).hasSize(2);
+        assertThat(response.getBody().getDetails()).anyMatch(d -> d.contains("amount"));
+        assertThat(response.getBody().getDetails()).anyMatch(d -> d.contains("orderId"));
+    }
+
+    @Test
+    @DisplayName("handleGenericException - debe retornar 500 INTERNAL_SERVER_ERROR")
+    void handleGenericException_Returns500() {
+        // Given
+        Exception ex = new RuntimeException("Error inesperado");
+
+        // When
+        ResponseEntity<ErrorResponse> response =
+                globalExceptionHandler.handleGenericException(ex, request);
+
+        // Then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getStatus()).isEqualTo(500);
+        assertThat(response.getBody().getError()).isEqualTo("Error interno del servidor");
+    }
+}

--- a/payment-service/src/test/java/com/microcommerce/payment/mapper/PaymentMapperTest.java
+++ b/payment-service/src/test/java/com/microcommerce/payment/mapper/PaymentMapperTest.java
@@ -1,0 +1,164 @@
+package com.microcommerce.payment.mapper;
+
+import com.microcommerce.payment.dto.request.PaymentRequest;
+import com.microcommerce.payment.dto.response.PaymentResponse;
+import com.microcommerce.payment.entity.Payment;
+import com.microcommerce.payment.entity.PaymentMethod;
+import com.microcommerce.payment.entity.PaymentStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.*;
+
+/**
+ * Unit tests for PaymentMapper
+ * Tests unitarios para PaymentMapper
+ */
+@DisplayName("PaymentMapper Tests")
+class PaymentMapperTest {
+
+    private PaymentMapper paymentMapper;
+
+    @BeforeEach
+    void setUp() {
+        paymentMapper = new PaymentMapper();
+    }
+
+    // ==================== toEntity Tests ====================
+
+    @Test
+    @DisplayName("toEntity - request valido - debe retornar Payment entity completa")
+    void toEntity_ValidRequest_ReturnsPaymentEntity() {
+        // Given
+        PaymentRequest request = PaymentRequest.builder()
+                .orderId(100L)
+                .userId(200L)
+                .amount(new BigDecimal("99.99"))
+                .currency("USD")
+                .paymentMethod(PaymentMethod.CREDIT_CARD)
+                .description("Test payment")
+                .paymentToken("pm_test_visa_001")
+                .build();
+
+        // When
+        Payment result = paymentMapper.toEntity(request);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result.getOrderId()).isEqualTo(100L);
+        assertThat(result.getUserId()).isEqualTo(200L);
+        assertThat(result.getAmount()).isEqualByComparingTo(new BigDecimal("99.99"));
+        assertThat(result.getCurrency()).isEqualTo("USD");
+        assertThat(result.getPaymentMethod()).isEqualTo(PaymentMethod.CREDIT_CARD);
+        assertThat(result.getDescription()).isEqualTo("Test payment");
+    }
+
+    @Test
+    @DisplayName("toEntity - moneda nula - debe usar USD por defecto")
+    void toEntity_NullCurrency_UsesDefaultUsd() {
+        // Given
+        PaymentRequest request = PaymentRequest.builder()
+                .orderId(100L)
+                .userId(200L)
+                .amount(new BigDecimal("50.00"))
+                .currency(null)
+                .paymentMethod(PaymentMethod.DEBIT_CARD)
+                .build();
+
+        // When
+        Payment result = paymentMapper.toEntity(request);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result.getCurrency()).isEqualTo("USD");
+    }
+
+    @Test
+    @DisplayName("toEntity - request nulo - debe retornar null")
+    void toEntity_NullRequest_ReturnsNull() {
+        // When
+        Payment result = paymentMapper.toEntity(null);
+
+        // Then
+        assertThat(result).isNull();
+    }
+
+    // ==================== toResponse Tests ====================
+
+    @Test
+    @DisplayName("toResponse - payment valido - debe retornar PaymentResponse completo")
+    void toResponse_ValidPayment_ReturnsPaymentResponse() {
+        // Given
+        LocalDateTime now = LocalDateTime.now();
+        Payment payment = Payment.builder()
+                .id(1L)
+                .orderId(100L)
+                .userId(200L)
+                .amount(new BigDecimal("99.99"))
+                .currency("USD")
+                .status(PaymentStatus.COMPLETED)
+                .paymentMethod(PaymentMethod.CREDIT_CARD)
+                .stripePaymentIntentId("pi_test_123")
+                .description("Test payment")
+                .failureReason(null)
+                .createdAt(now)
+                .updatedAt(now)
+                .build();
+
+        // When
+        PaymentResponse result = paymentMapper.toResponse(payment);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result.getId()).isEqualTo(1L);
+        assertThat(result.getOrderId()).isEqualTo(100L);
+        assertThat(result.getUserId()).isEqualTo(200L);
+        assertThat(result.getAmount()).isEqualByComparingTo(new BigDecimal("99.99"));
+        assertThat(result.getCurrency()).isEqualTo("USD");
+        assertThat(result.getStatus()).isEqualTo(PaymentStatus.COMPLETED);
+        assertThat(result.getPaymentMethod()).isEqualTo(PaymentMethod.CREDIT_CARD);
+        assertThat(result.getStripePaymentIntentId()).isEqualTo("pi_test_123");
+        assertThat(result.getDescription()).isEqualTo("Test payment");
+        assertThat(result.getFailureReason()).isNull();
+        assertThat(result.getCreatedAt()).isEqualTo(now);
+        assertThat(result.getUpdatedAt()).isEqualTo(now);
+    }
+
+    @Test
+    @DisplayName("toResponse - payment con failure reason - debe incluir failure reason")
+    void toResponse_PaymentWithFailureReason_IncludesFailureReason() {
+        // Given
+        Payment payment = Payment.builder()
+                .id(1L)
+                .orderId(100L)
+                .userId(200L)
+                .amount(new BigDecimal("99.99"))
+                .currency("USD")
+                .status(PaymentStatus.FAILED)
+                .paymentMethod(PaymentMethod.CREDIT_CARD)
+                .failureReason("Tarjeta rechazada")
+                .build();
+
+        // When
+        PaymentResponse result = paymentMapper.toResponse(payment);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result.getStatus()).isEqualTo(PaymentStatus.FAILED);
+        assertThat(result.getFailureReason()).isEqualTo("Tarjeta rechazada");
+    }
+
+    @Test
+    @DisplayName("toResponse - payment nulo - debe retornar null")
+    void toResponse_NullPayment_ReturnsNull() {
+        // When
+        PaymentResponse result = paymentMapper.toResponse(null);
+
+        // Then
+        assertThat(result).isNull();
+    }
+}

--- a/payment-service/src/test/java/com/microcommerce/payment/repository/PaymentRepositoryIntegrationTest.java
+++ b/payment-service/src/test/java/com/microcommerce/payment/repository/PaymentRepositoryIntegrationTest.java
@@ -1,0 +1,244 @@
+package com.microcommerce.payment.repository;
+
+import com.microcommerce.payment.entity.Payment;
+import com.microcommerce.payment.entity.PaymentMethod;
+import com.microcommerce.payment.entity.PaymentStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+
+/**
+ * Integration tests for PaymentRepository using TestContainers with PostgreSQL
+ * Tests de integracion para PaymentRepository usando TestContainers con PostgreSQL
+ */
+@DataJpaTest
+@Testcontainers
+@ActiveProfiles("test-tc")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@DisplayName("PaymentRepository Integration Tests")
+class PaymentRepositoryIntegrationTest {
+
+    @Container
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:15-alpine")
+            .withDatabaseName("payment_test_db")
+            .withUsername("test")
+            .withPassword("test");
+
+    @DynamicPropertySource
+    static void configureProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+    }
+
+    @Autowired
+    private PaymentRepository paymentRepository;
+
+    private Payment completedPayment;
+    private Payment pendingPayment;
+    private Payment failedPayment;
+
+    @BeforeEach
+    void setUp() {
+        paymentRepository.deleteAll();
+
+        completedPayment = paymentRepository.save(Payment.builder()
+                .orderId(100L)
+                .userId(200L)
+                .amount(new BigDecimal("99.99"))
+                .currency("USD")
+                .status(PaymentStatus.COMPLETED)
+                .paymentMethod(PaymentMethod.CREDIT_CARD)
+                .stripePaymentIntentId("pi_test_completed_001")
+                .stripeChargeId("ch_test_charge_001")
+                .description("Completed payment")
+                .build());
+
+        pendingPayment = paymentRepository.save(Payment.builder()
+                .orderId(101L)
+                .userId(200L)
+                .amount(new BigDecimal("49.50"))
+                .currency("USD")
+                .status(PaymentStatus.PENDING)
+                .paymentMethod(PaymentMethod.DEBIT_CARD)
+                .description("Pending payment")
+                .build());
+
+        failedPayment = paymentRepository.save(Payment.builder()
+                .orderId(102L)
+                .userId(300L)
+                .amount(new BigDecimal("15.00"))
+                .currency("EUR")
+                .status(PaymentStatus.FAILED)
+                .paymentMethod(PaymentMethod.DIGITAL_WALLET)
+                .failureReason("Tarjeta rechazada")
+                .description("Failed payment")
+                .build());
+    }
+
+    @Test
+    @DisplayName("findByOrderId - debe retornar pagos de la orden")
+    void findByOrderId_ReturnsPaymentsForOrder() {
+        // When
+        List<Payment> result = paymentRepository.findByOrderId(100L);
+
+        // Then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getOrderId()).isEqualTo(100L);
+        assertThat(result.get(0).getStatus()).isEqualTo(PaymentStatus.COMPLETED);
+    }
+
+    @Test
+    @DisplayName("findByOrderId - orden sin pagos - debe retornar lista vacia")
+    void findByOrderId_NoPayments_ReturnsEmptyList() {
+        // When
+        List<Payment> result = paymentRepository.findByOrderId(999L);
+
+        // Then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("findByUserId - debe retornar pagos del usuario")
+    void findByUserId_ReturnsPaymentsForUser() {
+        // When
+        List<Payment> result = paymentRepository.findByUserId(200L);
+
+        // Then
+        assertThat(result).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("findByStripePaymentIntentId - ID existente - debe retornar pago")
+    void findByStripePaymentIntentId_ExistingId_ReturnsPayment() {
+        // When
+        Optional<Payment> result = paymentRepository
+                .findByStripePaymentIntentId("pi_test_completed_001");
+
+        // Then
+        assertThat(result).isPresent();
+        assertThat(result.get().getStripePaymentIntentId()).isEqualTo("pi_test_completed_001");
+    }
+
+    @Test
+    @DisplayName("findByStripePaymentIntentId - ID no existente - debe retornar empty")
+    void findByStripePaymentIntentId_NonExistingId_ReturnsEmpty() {
+        // When
+        Optional<Payment> result = paymentRepository
+                .findByStripePaymentIntentId("pi_nonexistent");
+
+        // Then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("findByStatus - debe retornar pagos con el estado dado")
+    void findByStatus_ReturnsPaymentsWithGivenStatus() {
+        // When
+        List<Payment> result = paymentRepository.findByStatus(PaymentStatus.COMPLETED);
+
+        // Then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getStatus()).isEqualTo(PaymentStatus.COMPLETED);
+    }
+
+    @Test
+    @DisplayName("findByUserIdAndStatus - debe retornar pagos filtrados por usuario y estado")
+    void findByUserIdAndStatus_ReturnsFilteredPayments() {
+        // When
+        List<Payment> result = paymentRepository
+                .findByUserIdAndStatus(200L, PaymentStatus.PENDING);
+
+        // Then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getUserId()).isEqualTo(200L);
+        assertThat(result.get(0).getStatus()).isEqualTo(PaymentStatus.PENDING);
+    }
+
+    @Test
+    @DisplayName("countByStatus - debe retornar cantidad correcta")
+    void countByStatus_ReturnsCorrectCount() {
+        // When
+        long completedCount = paymentRepository.countByStatus(PaymentStatus.COMPLETED);
+        long pendingCount = paymentRepository.countByStatus(PaymentStatus.PENDING);
+        long refundedCount = paymentRepository.countByStatus(PaymentStatus.REFUNDED);
+
+        // Then
+        assertThat(completedCount).isEqualTo(1);
+        assertThat(pendingCount).isEqualTo(1);
+        assertThat(refundedCount).isZero();
+    }
+
+    @Test
+    @DisplayName("existsByOrderIdAndStatusIn - orden con pago activo - debe retornar true")
+    void existsByOrderIdAndStatusIn_ActivePayment_ReturnsTrue() {
+        // When
+        boolean exists = paymentRepository.existsByOrderIdAndStatusIn(
+                100L, List.of(PaymentStatus.COMPLETED, PaymentStatus.PROCESSING));
+
+        // Then
+        assertThat(exists).isTrue();
+    }
+
+    @Test
+    @DisplayName("existsByOrderIdAndStatusIn - orden sin pago activo - debe retornar false")
+    void existsByOrderIdAndStatusIn_NoActivePayment_ReturnsFalse() {
+        // When
+        boolean exists = paymentRepository.existsByOrderIdAndStatusIn(
+                102L, List.of(PaymentStatus.COMPLETED, PaymentStatus.PROCESSING));
+
+        // Then
+        assertThat(exists).isFalse();
+    }
+
+    @Test
+    @DisplayName("save - nuevo pago - debe persistir correctamente con timestamps")
+    void save_NewPayment_PersistsWithTimestamps() {
+        // Given
+        Payment newPayment = Payment.builder()
+                .orderId(500L)
+                .userId(600L)
+                .amount(new BigDecimal("200.00"))
+                .currency("USD")
+                .status(PaymentStatus.PENDING)
+                .paymentMethod(PaymentMethod.BANK_TRANSFER)
+                .description("New test payment")
+                .build();
+
+        // When
+        Payment saved = paymentRepository.save(newPayment);
+
+        // Then
+        assertThat(saved.getId()).isNotNull();
+        assertThat(saved.getCreatedAt()).isNotNull();
+        assertThat(saved.getOrderId()).isEqualTo(500L);
+        assertThat(saved.getAmount()).isEqualByComparingTo(new BigDecimal("200.00"));
+    }
+
+    @Test
+    @DisplayName("findByCreatedAtBetween - debe retornar pagos en rango de fechas")
+    void findByCreatedAtBetween_ReturnsPaymentsInDateRange() {
+        // When - all test payments were just created, so they should be in the current time range
+        List<Payment> result = paymentRepository.findByCreatedAtBetween(
+                java.time.LocalDateTime.now().minusMinutes(5),
+                java.time.LocalDateTime.now().plusMinutes(5));
+
+        // Then
+        assertThat(result).hasSize(3);
+    }
+}

--- a/payment-service/src/test/java/com/microcommerce/payment/service/PaymentServiceImplTest.java
+++ b/payment-service/src/test/java/com/microcommerce/payment/service/PaymentServiceImplTest.java
@@ -1,0 +1,602 @@
+package com.microcommerce.payment.service;
+
+import com.microcommerce.payment.client.StripeClient;
+import com.microcommerce.payment.dto.request.PaymentRequest;
+import com.microcommerce.payment.dto.request.RefundRequest;
+import com.microcommerce.payment.dto.response.PaymentResponse;
+import com.microcommerce.payment.dto.response.StripePaymentIntentResponse;
+import com.microcommerce.payment.dto.response.StripeRefundResponse;
+import com.microcommerce.payment.entity.Payment;
+import com.microcommerce.payment.entity.PaymentMethod;
+import com.microcommerce.payment.entity.PaymentStatus;
+import com.microcommerce.payment.exception.InvalidPaymentStateException;
+import com.microcommerce.payment.exception.PaymentAlreadyProcessedException;
+import com.microcommerce.payment.exception.PaymentGatewayException;
+import com.microcommerce.payment.exception.PaymentNotFoundException;
+import com.microcommerce.payment.mapper.PaymentMapper;
+import com.microcommerce.payment.repository.PaymentRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for PaymentServiceImpl
+ * Tests unitarios para PaymentServiceImpl
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("PaymentServiceImpl Tests")
+class PaymentServiceImplTest {
+
+    @Mock
+    private PaymentRepository paymentRepository;
+
+    @Mock
+    private PaymentMapper paymentMapper;
+
+    @Mock
+    private StripeClient stripeClient;
+
+    @InjectMocks
+    private PaymentServiceImpl paymentService;
+
+    private Payment payment;
+    private Payment completedPayment;
+    private Payment pendingPayment;
+    private PaymentRequest paymentRequest;
+    private RefundRequest refundRequest;
+    private PaymentResponse paymentResponse;
+    private StripePaymentIntentResponse stripeSuccessResponse;
+    private StripeRefundResponse stripeRefundSuccessResponse;
+
+    @BeforeEach
+    void setUp() {
+        // Setup pending payment
+        pendingPayment = Payment.builder()
+                .id(1L)
+                .orderId(100L)
+                .userId(200L)
+                .amount(new BigDecimal("99.99"))
+                .currency("USD")
+                .status(PaymentStatus.PENDING)
+                .paymentMethod(PaymentMethod.CREDIT_CARD)
+                .description("Order #100 payment")
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build();
+
+        // Setup completed payment
+        completedPayment = Payment.builder()
+                .id(2L)
+                .orderId(101L)
+                .userId(200L)
+                .amount(new BigDecimal("249.50"))
+                .currency("USD")
+                .status(PaymentStatus.COMPLETED)
+                .paymentMethod(PaymentMethod.DEBIT_CARD)
+                .stripePaymentIntentId("pi_test_completed_001")
+                .stripeChargeId("ch_test_charge_001")
+                .description("Order #101 payment")
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build();
+
+        // Default payment used in process tests
+        payment = Payment.builder()
+                .id(1L)
+                .orderId(100L)
+                .userId(200L)
+                .amount(new BigDecimal("99.99"))
+                .currency("USD")
+                .status(PaymentStatus.PENDING)
+                .paymentMethod(PaymentMethod.CREDIT_CARD)
+                .description("Order #100 payment")
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build();
+
+        // Setup PaymentRequest
+        paymentRequest = PaymentRequest.builder()
+                .orderId(100L)
+                .userId(200L)
+                .amount(new BigDecimal("99.99"))
+                .currency("USD")
+                .paymentMethod(PaymentMethod.CREDIT_CARD)
+                .description("Order #100 payment")
+                .paymentToken("pm_test_visa_001")
+                .build();
+
+        // Setup RefundRequest
+        refundRequest = RefundRequest.builder()
+                .amount(new BigDecimal("50.00"))
+                .reason("Customer requested refund")
+                .build();
+
+        // Setup PaymentResponse
+        paymentResponse = PaymentResponse.builder()
+                .id(1L)
+                .orderId(100L)
+                .userId(200L)
+                .amount(new BigDecimal("99.99"))
+                .currency("USD")
+                .status(PaymentStatus.COMPLETED)
+                .paymentMethod(PaymentMethod.CREDIT_CARD)
+                .stripePaymentIntentId("pi_test_123456789")
+                .description("Order #100 payment")
+                .build();
+
+        // Setup Stripe success response
+        stripeSuccessResponse = StripePaymentIntentResponse.builder()
+                .id("pi_test_123456789")
+                .object("payment_intent")
+                .amount(9999L)
+                .currency("usd")
+                .status("succeeded")
+                .clientSecret("pi_test_123456789_secret_abc")
+                .paymentMethod("pm_test_visa_001")
+                .latestCharge("ch_test_charge_001")
+                .description("Order #100 payment")
+                .created(1700000000L)
+                .build();
+
+        // Setup Stripe refund success response
+        stripeRefundSuccessResponse = StripeRefundResponse.builder()
+                .id("re_test_refund_001")
+                .object("refund")
+                .amount(5000L)
+                .currency("usd")
+                .paymentIntent("pi_test_completed_001")
+                .status("succeeded")
+                .reason("requested_by_customer")
+                .created(1700001000L)
+                .build();
+
+        // Common mock setups
+        when(paymentMapper.toEntity(any(PaymentRequest.class))).thenReturn(payment);
+        when(paymentMapper.toResponse(any(Payment.class))).thenReturn(paymentResponse);
+    }
+
+    // ==================== processPayment Tests ====================
+
+    @Test
+    @DisplayName("processPayment - pago exitoso con Stripe - debe retornar PaymentResponse completado")
+    void processPayment_SuccessfulStripePayment_ReturnsCompletedPaymentResponse() {
+        // Given
+        when(paymentRepository.existsByOrderIdAndStatusIn(eq(100L), anyList())).thenReturn(false);
+        when(paymentRepository.save(any(Payment.class))).thenReturn(payment);
+        when(stripeClient.createPaymentIntent(any())).thenReturn(stripeSuccessResponse);
+
+        // When
+        PaymentResponse result = paymentService.processPayment(paymentRequest);
+
+        // Then
+        assertThat(result).isNotNull();
+        verify(paymentRepository).existsByOrderIdAndStatusIn(eq(100L), anyList());
+        verify(paymentMapper).toEntity(paymentRequest);
+        verify(stripeClient).createPaymentIntent(any());
+        verify(paymentRepository, times(3)).save(any(Payment.class));
+    }
+
+    @Test
+    @DisplayName("processPayment - orden con pago existente - debe lanzar PaymentAlreadyProcessedException")
+    void processPayment_ExistingActivePayment_ThrowsPaymentAlreadyProcessedException() {
+        // Given
+        when(paymentRepository.existsByOrderIdAndStatusIn(eq(100L), anyList())).thenReturn(true);
+
+        // When & Then
+        assertThatThrownBy(() -> paymentService.processPayment(paymentRequest))
+                .isInstanceOf(PaymentAlreadyProcessedException.class);
+        verify(paymentRepository, never()).save(any());
+        verify(stripeClient, never()).createPaymentIntent(any());
+    }
+
+    @Test
+    @DisplayName("processPayment - Stripe requiere accion adicional - debe quedar en PROCESSING")
+    void processPayment_StripeRequiresAction_StatusProcessing() {
+        // Given
+        StripePaymentIntentResponse requiresActionResponse = StripePaymentIntentResponse.builder()
+                .id("pi_test_requires_action")
+                .status("requires_action")
+                .latestCharge(null)
+                .build();
+
+        when(paymentRepository.existsByOrderIdAndStatusIn(eq(100L), anyList())).thenReturn(false);
+        when(paymentRepository.save(any(Payment.class))).thenReturn(payment);
+        when(stripeClient.createPaymentIntent(any())).thenReturn(requiresActionResponse);
+
+        // When
+        paymentService.processPayment(paymentRequest);
+
+        // Then
+        verify(stripeClient).createPaymentIntent(any());
+        verify(paymentRepository, times(3)).save(any(Payment.class));
+    }
+
+    @Test
+    @DisplayName("processPayment - Stripe retorna estado inesperado - debe quedar en FAILED")
+    void processPayment_StripeUnexpectedStatus_StatusFailed() {
+        // Given
+        StripePaymentIntentResponse unexpectedResponse = StripePaymentIntentResponse.builder()
+                .id("pi_test_unexpected")
+                .status("canceled")
+                .latestCharge(null)
+                .build();
+
+        when(paymentRepository.existsByOrderIdAndStatusIn(eq(100L), anyList())).thenReturn(false);
+        when(paymentRepository.save(any(Payment.class))).thenReturn(payment);
+        when(stripeClient.createPaymentIntent(any())).thenReturn(unexpectedResponse);
+
+        // When
+        paymentService.processPayment(paymentRequest);
+
+        // Then
+        verify(paymentRepository, times(3)).save(any(Payment.class));
+    }
+
+    @Test
+    @DisplayName("processPayment - error de Stripe - debe marcar pago como FAILED")
+    void processPayment_StripeException_PaymentMarkedAsFailed() {
+        // Given
+        when(paymentRepository.existsByOrderIdAndStatusIn(eq(100L), anyList())).thenReturn(false);
+        when(paymentRepository.save(any(Payment.class))).thenReturn(payment);
+        when(stripeClient.createPaymentIntent(any()))
+                .thenThrow(new PaymentGatewayException("Error de conexion con Stripe"));
+
+        // When
+        PaymentResponse result = paymentService.processPayment(paymentRequest);
+
+        // Then
+        assertThat(result).isNotNull();
+        verify(paymentRepository, times(3)).save(any(Payment.class));
+    }
+
+    @Test
+    @DisplayName("processPayment - moneda nula - debe usar USD por defecto")
+    void processPayment_NullCurrency_UsesDefaultUsd() {
+        // Given
+        PaymentRequest requestNullCurrency = PaymentRequest.builder()
+                .orderId(100L)
+                .userId(200L)
+                .amount(new BigDecimal("99.99"))
+                .currency(null)
+                .paymentMethod(PaymentMethod.CREDIT_CARD)
+                .paymentToken("pm_test_visa_001")
+                .build();
+
+        when(paymentRepository.existsByOrderIdAndStatusIn(eq(100L), anyList())).thenReturn(false);
+        when(paymentRepository.save(any(Payment.class))).thenReturn(payment);
+        when(stripeClient.createPaymentIntent(any())).thenReturn(stripeSuccessResponse);
+
+        // When
+        paymentService.processPayment(requestNullCurrency);
+
+        // Then
+        verify(stripeClient).createPaymentIntent(argThat(req ->
+                "usd".equals(req.getCurrency())));
+    }
+
+    // ==================== getPaymentById Tests ====================
+
+    @Test
+    @DisplayName("getPaymentById - ID existente - debe retornar PaymentResponse")
+    void getPaymentById_ExistingId_ReturnsPaymentResponse() {
+        // Given
+        when(paymentRepository.findById(1L)).thenReturn(Optional.of(payment));
+
+        // When
+        PaymentResponse result = paymentService.getPaymentById(1L);
+
+        // Then
+        assertThat(result).isNotNull();
+        verify(paymentRepository).findById(1L);
+        verify(paymentMapper).toResponse(payment);
+    }
+
+    @Test
+    @DisplayName("getPaymentById - ID no existente - debe lanzar PaymentNotFoundException")
+    void getPaymentById_NonExistingId_ThrowsPaymentNotFoundException() {
+        // Given
+        when(paymentRepository.findById(999L)).thenReturn(Optional.empty());
+
+        // When & Then
+        assertThatThrownBy(() -> paymentService.getPaymentById(999L))
+                .isInstanceOf(PaymentNotFoundException.class);
+    }
+
+    // ==================== getPaymentByStripeIntentId Tests ====================
+
+    @Test
+    @DisplayName("getPaymentByStripeIntentId - ID existente - debe retornar PaymentResponse")
+    void getPaymentByStripeIntentId_ExistingId_ReturnsPaymentResponse() {
+        // Given
+        when(paymentRepository.findByStripePaymentIntentId("pi_test_123456789"))
+                .thenReturn(Optional.of(payment));
+
+        // When
+        PaymentResponse result = paymentService.getPaymentByStripeIntentId("pi_test_123456789");
+
+        // Then
+        assertThat(result).isNotNull();
+        verify(paymentRepository).findByStripePaymentIntentId("pi_test_123456789");
+    }
+
+    @Test
+    @DisplayName("getPaymentByStripeIntentId - ID no existente - debe lanzar PaymentNotFoundException")
+    void getPaymentByStripeIntentId_NonExistingId_ThrowsPaymentNotFoundException() {
+        // Given
+        when(paymentRepository.findByStripePaymentIntentId("pi_nonexistent"))
+                .thenReturn(Optional.empty());
+
+        // When & Then
+        assertThatThrownBy(() -> paymentService.getPaymentByStripeIntentId("pi_nonexistent"))
+                .isInstanceOf(PaymentNotFoundException.class)
+                .hasMessageContaining("pi_nonexistent");
+    }
+
+    // ==================== getPaymentsByOrderId Tests ====================
+
+    @Test
+    @DisplayName("getPaymentsByOrderId - orden con pagos - debe retornar lista de PaymentResponse")
+    void getPaymentsByOrderId_OrderWithPayments_ReturnsPaymentResponseList() {
+        // Given
+        when(paymentRepository.findByOrderId(100L)).thenReturn(List.of(payment));
+
+        // When
+        List<PaymentResponse> result = paymentService.getPaymentsByOrderId(100L);
+
+        // Then
+        assertThat(result).hasSize(1);
+        verify(paymentRepository).findByOrderId(100L);
+    }
+
+    @Test
+    @DisplayName("getPaymentsByOrderId - orden sin pagos - debe retornar lista vacia")
+    void getPaymentsByOrderId_OrderWithNoPayments_ReturnsEmptyList() {
+        // Given
+        when(paymentRepository.findByOrderId(999L)).thenReturn(Collections.emptyList());
+
+        // When
+        List<PaymentResponse> result = paymentService.getPaymentsByOrderId(999L);
+
+        // Then
+        assertThat(result).isEmpty();
+    }
+
+    // ==================== getPaymentsByUserId Tests ====================
+
+    @Test
+    @DisplayName("getPaymentsByUserId - usuario con pagos - debe retornar lista")
+    void getPaymentsByUserId_UserWithPayments_ReturnsList() {
+        // Given
+        when(paymentRepository.findByUserId(200L)).thenReturn(List.of(payment, completedPayment));
+
+        // When
+        List<PaymentResponse> result = paymentService.getPaymentsByUserId(200L);
+
+        // Then
+        assertThat(result).hasSize(2);
+        verify(paymentRepository).findByUserId(200L);
+    }
+
+    @Test
+    @DisplayName("getPaymentsByUserId - usuario sin pagos - debe retornar lista vacia")
+    void getPaymentsByUserId_UserWithNoPayments_ReturnsEmptyList() {
+        // Given
+        when(paymentRepository.findByUserId(999L)).thenReturn(Collections.emptyList());
+
+        // When
+        List<PaymentResponse> result = paymentService.getPaymentsByUserId(999L);
+
+        // Then
+        assertThat(result).isEmpty();
+    }
+
+    // ==================== getPaymentsByUserIdAndStatus Tests ====================
+
+    @Test
+    @DisplayName("getPaymentsByUserIdAndStatus - usuario y estado validos - debe retornar lista filtrada")
+    void getPaymentsByUserIdAndStatus_ValidUserAndStatus_ReturnsFilteredList() {
+        // Given
+        when(paymentRepository.findByUserIdAndStatus(200L, PaymentStatus.COMPLETED))
+                .thenReturn(List.of(completedPayment));
+
+        // When
+        List<PaymentResponse> result = paymentService.getPaymentsByUserIdAndStatus(200L, PaymentStatus.COMPLETED);
+
+        // Then
+        assertThat(result).hasSize(1);
+        verify(paymentRepository).findByUserIdAndStatus(200L, PaymentStatus.COMPLETED);
+    }
+
+    // ==================== getPaymentsByStatus Tests ====================
+
+    @Test
+    @DisplayName("getPaymentsByStatus - estado con pagos - debe retornar lista")
+    void getPaymentsByStatus_StatusWithPayments_ReturnsList() {
+        // Given
+        when(paymentRepository.findByStatus(PaymentStatus.PENDING))
+                .thenReturn(List.of(pendingPayment));
+
+        // When
+        List<PaymentResponse> result = paymentService.getPaymentsByStatus(PaymentStatus.PENDING);
+
+        // Then
+        assertThat(result).hasSize(1);
+        verify(paymentRepository).findByStatus(PaymentStatus.PENDING);
+    }
+
+    @Test
+    @DisplayName("getPaymentsByStatus - estado sin pagos - debe retornar lista vacia")
+    void getPaymentsByStatus_StatusWithNoPayments_ReturnsEmptyList() {
+        // Given
+        when(paymentRepository.findByStatus(PaymentStatus.REFUNDED))
+                .thenReturn(Collections.emptyList());
+
+        // When
+        List<PaymentResponse> result = paymentService.getPaymentsByStatus(PaymentStatus.REFUNDED);
+
+        // Then
+        assertThat(result).isEmpty();
+    }
+
+    // ==================== refundPayment Tests ====================
+
+    @Test
+    @DisplayName("refundPayment - pago completado con reembolso valido - debe retornar PaymentResponse reembolsado")
+    void refundPayment_CompletedPaymentValidRefund_ReturnsRefundedPaymentResponse() {
+        // Given
+        when(paymentRepository.findById(2L)).thenReturn(Optional.of(completedPayment));
+        when(stripeClient.createRefund("pi_test_completed_001", new BigDecimal("50.00"), "Customer requested refund"))
+                .thenReturn(stripeRefundSuccessResponse);
+        when(paymentRepository.save(any(Payment.class))).thenReturn(completedPayment);
+
+        // When
+        PaymentResponse result = paymentService.refundPayment(2L, refundRequest);
+
+        // Then
+        assertThat(result).isNotNull();
+        verify(stripeClient).createRefund("pi_test_completed_001", new BigDecimal("50.00"), "Customer requested refund");
+        verify(paymentRepository).save(any(Payment.class));
+    }
+
+    @Test
+    @DisplayName("refundPayment - pago no completado - debe lanzar InvalidPaymentStateException")
+    void refundPayment_NonCompletedPayment_ThrowsInvalidPaymentStateException() {
+        // Given
+        when(paymentRepository.findById(1L)).thenReturn(Optional.of(pendingPayment));
+
+        // When & Then
+        assertThatThrownBy(() -> paymentService.refundPayment(1L, refundRequest))
+                .isInstanceOf(InvalidPaymentStateException.class)
+                .hasMessageContaining("Solo se pueden reembolsar pagos completados");
+        verify(stripeClient, never()).createRefund(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("refundPayment - monto mayor al pago original - debe lanzar InvalidPaymentStateException")
+    void refundPayment_AmountExceedsOriginal_ThrowsInvalidPaymentStateException() {
+        // Given
+        RefundRequest excessiveRefund = RefundRequest.builder()
+                .amount(new BigDecimal("500.00"))
+                .reason("Excessive refund attempt")
+                .build();
+        when(paymentRepository.findById(2L)).thenReturn(Optional.of(completedPayment));
+
+        // When & Then
+        assertThatThrownBy(() -> paymentService.refundPayment(2L, excessiveRefund))
+                .isInstanceOf(InvalidPaymentStateException.class)
+                .hasMessageContaining("El monto de reembolso no puede exceder");
+        verify(stripeClient, never()).createRefund(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("refundPayment - pago no encontrado - debe lanzar PaymentNotFoundException")
+    void refundPayment_PaymentNotFound_ThrowsPaymentNotFoundException() {
+        // Given
+        when(paymentRepository.findById(999L)).thenReturn(Optional.empty());
+
+        // When & Then
+        assertThatThrownBy(() -> paymentService.refundPayment(999L, refundRequest))
+                .isInstanceOf(PaymentNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("refundPayment - Stripe retorna estado no exitoso - debe registrar warning")
+    void refundPayment_StripeNonSucceededStatus_SetsFailureReason() {
+        // Given
+        StripeRefundResponse pendingRefundResponse = StripeRefundResponse.builder()
+                .id("re_test_pending")
+                .status("pending")
+                .build();
+
+        when(paymentRepository.findById(2L)).thenReturn(Optional.of(completedPayment));
+        when(stripeClient.createRefund(any(), any(), any())).thenReturn(pendingRefundResponse);
+        when(paymentRepository.save(any(Payment.class))).thenReturn(completedPayment);
+
+        // When
+        paymentService.refundPayment(2L, refundRequest);
+
+        // Then
+        verify(paymentRepository).save(argThat(p ->
+                p.getFailureReason() != null && p.getFailureReason().contains("pending")));
+    }
+
+    @Test
+    @DisplayName("refundPayment - monto nulo (reembolso completo) - no debe lanzar excepcion de monto")
+    void refundPayment_NullAmount_FullRefund_NoException() {
+        // Given
+        RefundRequest fullRefund = RefundRequest.builder()
+                .amount(null)
+                .reason("Full refund")
+                .build();
+
+        when(paymentRepository.findById(2L)).thenReturn(Optional.of(completedPayment));
+        when(stripeClient.createRefund("pi_test_completed_001", null, "Full refund"))
+                .thenReturn(stripeRefundSuccessResponse);
+        when(paymentRepository.save(any(Payment.class))).thenReturn(completedPayment);
+
+        // When
+        PaymentResponse result = paymentService.refundPayment(2L, fullRefund);
+
+        // Then
+        assertThat(result).isNotNull();
+        verify(stripeClient).createRefund("pi_test_completed_001", null, "Full refund");
+    }
+
+    // ==================== cancelPayment Tests ====================
+
+    @Test
+    @DisplayName("cancelPayment - pago pendiente - debe retornar PaymentResponse cancelado")
+    void cancelPayment_PendingPayment_ReturnsCancelledPaymentResponse() {
+        // Given
+        when(paymentRepository.findById(1L)).thenReturn(Optional.of(pendingPayment));
+        when(paymentRepository.save(any(Payment.class))).thenReturn(pendingPayment);
+
+        // When
+        PaymentResponse result = paymentService.cancelPayment(1L);
+
+        // Then
+        assertThat(result).isNotNull();
+        verify(paymentRepository).save(argThat(p -> p.getStatus() == PaymentStatus.CANCELLED));
+    }
+
+    @Test
+    @DisplayName("cancelPayment - pago no pendiente - debe lanzar InvalidPaymentStateException")
+    void cancelPayment_NonPendingPayment_ThrowsInvalidPaymentStateException() {
+        // Given
+        when(paymentRepository.findById(2L)).thenReturn(Optional.of(completedPayment));
+
+        // When & Then
+        assertThatThrownBy(() -> paymentService.cancelPayment(2L))
+                .isInstanceOf(InvalidPaymentStateException.class)
+                .hasMessageContaining("Solo se pueden cancelar pagos pendientes");
+        verify(paymentRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("cancelPayment - pago no encontrado - debe lanzar PaymentNotFoundException")
+    void cancelPayment_PaymentNotFound_ThrowsPaymentNotFoundException() {
+        // Given
+        when(paymentRepository.findById(999L)).thenReturn(Optional.empty());
+
+        // When & Then
+        assertThatThrownBy(() -> paymentService.cancelPayment(999L))
+                .isInstanceOf(PaymentNotFoundException.class);
+    }
+}

--- a/payment-service/src/test/resources/application-test-nodb.yml
+++ b/payment-service/src/test/resources/application-test-nodb.yml
@@ -1,17 +1,32 @@
+# Test configuration without database / Configuracion de test sin base de datos
+# Used for pure unit tests that mock the repository layer
+
 spring:
+  application:
+    name: payment-service-test-nodb
+
+  cloud:
+    config:
+      enabled: false
+    discovery:
+      enabled: false
+
   autoconfigure:
     exclude:
       - org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
       - org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration
-      - org.springframework.boot.autoconfigure.data.jpa.JpaRepositoriesAutoConfiguration
+
+# Stripe test configuration
+stripe:
+  api:
+    key: sk_test_fake_key_for_unit_tests
+    base-url: https://api.stripe.com/v1
 
 eureka:
   client:
     enabled: false
 
-stripe:
-  api:
-    key: sk_test_placeholder
-    base-url: https://api.stripe.com/v1
-  webhook:
-    secret: whsec_placeholder
+logging:
+  level:
+    root: WARN
+    com.microcommerce.payment: INFO

--- a/payment-service/src/test/resources/application-test-tc.yml
+++ b/payment-service/src/test/resources/application-test-tc.yml
@@ -1,20 +1,33 @@
+# Test configuration with TestContainers / Configuracion de test con TestContainers
+# Used for integration tests with real PostgreSQL
+
 spring:
+  application:
+    name: payment-service-test-tc
+
+  cloud:
+    config:
+      enabled: false
+    discovery:
+      enabled: false
+
   jpa:
     hibernate:
       ddl-auto: create-drop
-    show-sql: true
-    properties:
-      hibernate:
-        format_sql: true
-        dialect: org.hibernate.dialect.PostgreSQLDialect
+    show-sql: false
+
+# Stripe test configuration
+stripe:
+  api:
+    key: sk_test_fake_key_for_integration_tests
+    base-url: https://api.stripe.com/v1
 
 eureka:
   client:
     enabled: false
 
-stripe:
-  api:
-    key: sk_test_placeholder
-    base-url: https://api.stripe.com/v1
-  webhook:
-    secret: whsec_placeholder
+logging:
+  level:
+    root: WARN
+    com.microcommerce.payment: INFO
+    org.testcontainers: INFO

--- a/payment-service/src/test/resources/application.yml
+++ b/payment-service/src/test/resources/application.yml
@@ -1,35 +1,39 @@
+# Test configuration / Configuracion para tests
+
 spring:
   application:
-    name: payment-service
-  config:
-    import: ""
-  jpa:
-    hibernate:
-      ddl-auto: create-drop
-    show-sql: true
+    name: payment-service-test
 
+  # Disable Config Server in tests
+  cloud:
+    config:
+      enabled: false
+    discovery:
+      enabled: false
+
+# Stripe test configuration
+stripe:
+  api:
+    key: sk_test_fake_key_for_unit_tests
+    base-url: https://api.stripe.com/v1
+
+# Eureka disabled for tests
 eureka:
   client:
     enabled: false
 
-stripe:
-  api:
-    key: sk_test_placeholder
-    base-url: https://api.stripe.com/v1
-  webhook:
-    secret: whsec_placeholder
+# Actuator only health for tests
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health
 
-resilience4j:
-  circuitbreaker:
-    instances:
-      stripePayment:
-        register-health-indicator: false
-        sliding-window-size: 5
-        minimum-number-of-calls: 3
-        failure-rate-threshold: 50
-        wait-duration-in-open-state: 5s
-        permitted-number-of-calls-in-half-open-state: 2
-
+# Logs at WARN level for tests (less verbose)
 logging:
   level:
-    com.microcommerce.payment: DEBUG
+    root: WARN
+    com.microcommerce.payment: INFO
+    org.springframework: WARN
+    org.hibernate: WARN
+    org.testcontainers: INFO

--- a/payment-service/src/test/resources/mock/payments.json
+++ b/payment-service/src/test/resources/mock/payments.json
@@ -1,0 +1,29 @@
+[
+  {
+    "orderId": 1,
+    "userId": 100,
+    "amount": 99.99,
+    "currency": "USD",
+    "paymentMethod": "CREDIT_CARD",
+    "description": "Order #1 payment",
+    "paymentToken": "pm_test_visa_001"
+  },
+  {
+    "orderId": 2,
+    "userId": 100,
+    "amount": 249.50,
+    "currency": "USD",
+    "paymentMethod": "DEBIT_CARD",
+    "description": "Order #2 payment",
+    "paymentToken": "pm_test_debit_002"
+  },
+  {
+    "orderId": 3,
+    "userId": 200,
+    "amount": 15.00,
+    "currency": "EUR",
+    "paymentMethod": "DIGITAL_WALLET",
+    "description": "Order #3 payment",
+    "paymentToken": "pm_test_wallet_003"
+  }
+]

--- a/payment-service/src/test/resources/mock/refund-request.json
+++ b/payment-service/src/test/resources/mock/refund-request.json
@@ -1,0 +1,4 @@
+{
+  "amount": 50.00,
+  "reason": "Customer requested refund"
+}

--- a/payment-service/src/test/resources/mock/stripe-payment-intent-response.json
+++ b/payment-service/src/test/resources/mock/stripe-payment-intent-response.json
@@ -1,0 +1,12 @@
+{
+  "id": "pi_test_123456789",
+  "object": "payment_intent",
+  "amount": 9999,
+  "currency": "usd",
+  "status": "succeeded",
+  "clientSecret": "pi_test_123456789_secret_abc",
+  "paymentMethod": "pm_test_visa_001",
+  "latestCharge": "ch_test_charge_001",
+  "description": "Order #1 payment",
+  "created": 1700000000
+}

--- a/payment-service/src/test/resources/mock/stripe-refund-response.json
+++ b/payment-service/src/test/resources/mock/stripe-refund-response.json
@@ -1,0 +1,10 @@
+{
+  "id": "re_test_refund_001",
+  "object": "refund",
+  "amount": 5000,
+  "currency": "usd",
+  "paymentIntent": "pi_test_123456789",
+  "status": "succeeded",
+  "reason": "requested_by_customer",
+  "created": 1700001000
+}

--- a/payment-service/src/test/resources/testcontainers.properties
+++ b/payment-service/src/test/resources/testcontainers.properties
@@ -1,1 +1,10 @@
-ryuk.disabled=true
+# TestContainers configuration for Docker Desktop on Windows WSL2
+# Configuracion de TestContainers para Docker Desktop en Windows con WSL2
+
+# Disable Ryuk container reaper (puede causar problemas en Windows)
+testcontainers.ryuk.disabled=true
+
+# Enable container reuse for faster tests
+testcontainers.reuse.enable=false
+
+docker.host=unix:///var/run/docker.sock


### PR DESCRIPTION
## Summary
- Add comprehensive unit tests for PaymentServiceImpl covering all service methods (processPayment, refund, cancel, queries) with Mockito mocks for StripeClient, PaymentRepository and PaymentMapper
- Add unit tests for PaymentMapper, GlobalExceptionHandler, custom exceptions, ApiResponse and Stripe response DTOs
- Add integration tests for PaymentRepository using TestContainers with PostgreSQL
- Add mock JSON data files for payments, refund requests, and Stripe API responses in src/test/resources/mock/
- Add test configuration files (application.yml, application-test-nodb.yml, application-test-tc.yml, testcontainers.properties)

## Test plan
- [x] Verify unit tests compile successfully with `mvn test-compile`
- [x] Run unit tests with `mvn test` to confirm all pass
- [x] Verify integration tests pass with Docker running for TestContainers
- [x] Confirm test coverage meets 80% threshold configured in JaCoCo