### PR TITLE
feat(messaging): add event-driven communication with RabbitMQ

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,7 @@ POSTGRES_PASSWORD=your_postgres_password_here
 
 # Redis Configuration (no password for development)
 # REDIS_PASSWORD=your_redis_password_here
+
+# RabbitMQ Configuration
+RABBITMQ_USER=guest
+RABBITMQ_PASSWORD=guest

--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@
 - **MongoDB** - Order Service (planned)
 - **Redis 7** - Distributed Cache
 
+### Messaging
+- **RabbitMQ 3.13** - Event-Driven Communication (Order <-> Payment)
+
 ### Build & Deploy
 - **Maven 3.9+** - Build tool
 - **Docker & Docker Compose** - Containerization
@@ -222,13 +225,26 @@ MicroCommerce/
   -  REST Controller
   -  Tests unitarios e integración
 
+### [IMPLEMENTADO] Event-Driven con RabbitMQ
+
+- Exchanges topic: `orders.exchange`, `payments.exchange`
+- Eventos publicados por **Order Service**:
+  - `ORDER_CREATED` (routing key `order.created`)
+  - `ORDER_CANCELLED` (routing key `order.cancelled`)
+- Eventos publicados por **Payment Service**:
+  - `PAYMENT_COMPLETED` (routing key `payment.completed`)
+  - `PAYMENT_FAILED` (routing key `payment.failed`)
+  - `PAYMENT_REFUNDED` (routing key `payment.refunded`)
+- **Order Service** consume `payment.#` y actualiza el pedido a `PAID` cuando recibe `PAYMENT_COMPLETED`
+- Serializacion JSON via `Jackson2JsonMessageConverter`
+- Dead Letter Queue para eventos de pago rechazados
+- RabbitMQ Management UI: http://localhost:15672 (guest/guest)
+
 ###  [PRÓXIMOS] | Next
 
-- User Service con autenticación JWT
-- Payment Service con API externa
-- Event-driven architecture con RabbitMQ
-- Payment Service con integración externa
-- Tests unitarios e integración
+- Logging centralizado con ELK
+- Monitoring con Prometheus y Grafana
+- API Versioning
 - Despliegue en Kubernetes
 - CI/CD Pipeline
 

--- a/config/order-service.yml
+++ b/config/order-service.yml
@@ -16,6 +16,11 @@ spring:
     hibernate:
       ddl-auto: update
     show-sql: true
+  rabbitmq:
+    host: ${RABBITMQ_HOST:localhost}
+    port: ${RABBITMQ_PORT:5672}
+    username: ${RABBITMQ_USER:guest}
+    password: ${RABBITMQ_PASSWORD:guest}
 
 resilience4j:
   circuitbreaker:

--- a/config/payment-service.yml
+++ b/config/payment-service.yml
@@ -19,6 +19,11 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
+  rabbitmq:
+    host: ${RABBITMQ_HOST:localhost}
+    port: ${RABBITMQ_PORT:5672}
+    username: ${RABBITMQ_USER:guest}
+    password: ${RABBITMQ_PASSWORD:guest}
 
 stripe:
   api:

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -111,6 +111,27 @@ services:
     networks:
       - microcommerce-network
 
+  # RabbitMQ for event-driven communication
+  # RabbitMQ para comunicacion basada en eventos
+  rabbitmq:
+    image: rabbitmq:3.13-management-alpine
+    container_name: rabbitmq
+    environment:
+      RABBITMQ_DEFAULT_USER: ${RABBITMQ_USER:-guest}
+      RABBITMQ_DEFAULT_PASS: ${RABBITMQ_PASSWORD:-guest}
+    ports:
+      - "5672:5672"
+      - "15672:15672"
+    volumes:
+      - rabbitmq-data:/var/lib/rabbitmq
+    healthcheck:
+      test: ["CMD", "rabbitmq-diagnostics", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - microcommerce-network
+
 volumes:
   product-data:
     driver: local
@@ -121,6 +142,8 @@ volumes:
   order-mongo-data:
     driver: local
   redis-data:
+    driver: local
+  rabbitmq-data:
     driver: local
 
 networks:

--- a/order-service/pom.xml
+++ b/order-service/pom.xml
@@ -33,6 +33,12 @@
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
 
+        <!-- RabbitMQ for event-driven messaging -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-amqp</artifactId>
+        </dependency>
+
         <!-- Spring Cloud -->
         <dependency>
             <groupId>org.springframework.cloud</groupId>
@@ -103,6 +109,13 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Spring AMQP test support -->
+        <dependency>
+            <groupId>org.springframework.amqp</groupId>
+            <artifactId>spring-rabbit-test</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/order-service/src/main/java/com/microcommerce/order/config/RabbitMQConfig.java
+++ b/order-service/src/main/java/com/microcommerce/order/config/RabbitMQConfig.java
@@ -1,0 +1,122 @@
+package com.microcommerce.order.config;
+
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.BindingBuilder;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.core.QueueBuilder;
+import org.springframework.amqp.core.TopicExchange;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * RabbitMQ configuration for the Order Service.
+ * Configuracion de RabbitMQ para el Order Service.
+ *
+ * Declares the orders topic exchange and the payment events queue so the
+ * service can publish order events and consume payment events.
+ *
+ * Declara el topic exchange de ordenes y la cola de eventos de pagos para que
+ * el servicio pueda publicar eventos de pedido y consumir eventos de pago.
+ */
+@Configuration
+public class RabbitMQConfig {
+
+    public static final String ORDERS_EXCHANGE = "orders.exchange";
+    public static final String PAYMENTS_EXCHANGE = "payments.exchange";
+
+    public static final String ORDER_CREATED_ROUTING_KEY = "order.created";
+    public static final String ORDER_CANCELLED_ROUTING_KEY = "order.cancelled";
+    public static final String PAYMENT_EVENTS_ROUTING_KEY = "payment.#";
+
+    public static final String ORDER_PAYMENT_EVENTS_QUEUE = "order.payment-events.queue";
+    public static final String ORDER_PAYMENT_EVENTS_DLQ = "order.payment-events.dlq";
+    public static final String ORDER_PAYMENT_EVENTS_DLX = "order.payment-events.dlx";
+
+    /**
+     * Orders topic exchange where the service publishes its events.
+     * Topic exchange de ordenes donde el servicio publica sus eventos.
+     */
+    @Bean
+    public TopicExchange ordersExchange() {
+        return new TopicExchange(ORDERS_EXCHANGE, true, false);
+    }
+
+    /**
+     * Payments topic exchange (declared here so the consumer can bind without
+     * depending on the Payment Service startup order).
+     * Topic exchange de pagos (declarado aqui para que el consumidor pueda
+     * asociarse sin depender del arranque del Payment Service).
+     */
+    @Bean
+    public TopicExchange paymentsExchange() {
+        return new TopicExchange(PAYMENTS_EXCHANGE, true, false);
+    }
+
+    /**
+     * Dead letter exchange for rejected payment events.
+     * Exchange de dead letter para eventos de pago rechazados.
+     */
+    @Bean
+    public TopicExchange paymentEventsDeadLetterExchange() {
+        return new TopicExchange(ORDER_PAYMENT_EVENTS_DLX, true, false);
+    }
+
+    /**
+     * Dead letter queue for payment events.
+     * Cola de dead letter para eventos de pago.
+     */
+    @Bean
+    public Queue paymentEventsDeadLetterQueue() {
+        return QueueBuilder.durable(ORDER_PAYMENT_EVENTS_DLQ).build();
+    }
+
+    @Bean
+    public Binding paymentEventsDeadLetterBinding() {
+        return BindingBuilder.bind(paymentEventsDeadLetterQueue())
+                .to(paymentEventsDeadLetterExchange())
+                .with("#");
+    }
+
+    /**
+     * Queue consumed by this service to receive payment events.
+     * Cola consumida por este servicio para recibir eventos de pago.
+     */
+    @Bean
+    public Queue paymentEventsQueue() {
+        return QueueBuilder.durable(ORDER_PAYMENT_EVENTS_QUEUE)
+                .withArgument("x-dead-letter-exchange", ORDER_PAYMENT_EVENTS_DLX)
+                .build();
+    }
+
+    @Bean
+    public Binding paymentEventsBinding() {
+        return BindingBuilder.bind(paymentEventsQueue())
+                .to(paymentsExchange())
+                .with(PAYMENT_EVENTS_ROUTING_KEY);
+    }
+
+    /**
+     * Jackson JSON message converter for AMQP.
+     * Convertidor de mensajes JSON (Jackson) para AMQP.
+     */
+    @Bean
+    public MessageConverter jsonMessageConverter() {
+        return new Jackson2JsonMessageConverter();
+    }
+
+    /**
+     * RabbitTemplate configured with the JSON converter.
+     * RabbitTemplate configurado con el convertidor JSON.
+     */
+    @Bean
+    public RabbitTemplate rabbitTemplate(ConnectionFactory connectionFactory,
+                                         MessageConverter jsonMessageConverter) {
+        RabbitTemplate template = new RabbitTemplate(connectionFactory);
+        template.setMessageConverter(jsonMessageConverter);
+        return template;
+    }
+}

--- a/order-service/src/main/java/com/microcommerce/order/event/OrderEvent.java
+++ b/order-service/src/main/java/com/microcommerce/order/event/OrderEvent.java
@@ -1,0 +1,49 @@
+package com.microcommerce.order.event;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+/**
+ * Base event emitted by the Order Service when an order changes state.
+ * Evento base emitido por el Order Service cuando un pedido cambia de estado.
+ *
+ * This payload is serialized to JSON and routed through the orders exchange.
+ * Este payload se serializa a JSON y se enruta a traves del exchange de pedidos.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class OrderEvent implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    /** Unique event identifier. / Identificador unico del evento. */
+    private String eventId;
+
+    /** Event type (e.g. ORDER_CREATED, ORDER_CANCELLED). / Tipo de evento. */
+    private String eventType;
+
+    /** Order identifier. / Identificador del pedido. */
+    private String orderId;
+
+    /** User that owns the order. / Usuario duenio del pedido. */
+    private Long userId;
+
+    /** Order status at the time of the event. / Estado del pedido en el momento del evento. */
+    private String status;
+
+    /** Total amount of the order. / Monto total del pedido. */
+    private BigDecimal totalAmount;
+
+    /** Event timestamp. / Marca temporal del evento. */
+    @JsonFormat(shape = JsonFormat.Shape.STRING)
+    private LocalDateTime occurredAt;
+}

--- a/order-service/src/main/java/com/microcommerce/order/event/OrderEventPublisher.java
+++ b/order-service/src/main/java/com/microcommerce/order/event/OrderEventPublisher.java
@@ -1,0 +1,72 @@
+package com.microcommerce.order.event;
+
+import com.microcommerce.order.config.RabbitMQConfig;
+import com.microcommerce.order.entity.Order;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.AmqpException;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * Publishes order related events to the orders exchange.
+ * Publica eventos relacionados con pedidos al exchange de ordenes.
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class OrderEventPublisher {
+
+    public static final String EVENT_ORDER_CREATED = "ORDER_CREATED";
+    public static final String EVENT_ORDER_CANCELLED = "ORDER_CANCELLED";
+
+    private final RabbitTemplate rabbitTemplate;
+
+    /**
+     * Publish the event raised when a new order is created.
+     * Publica el evento generado cuando se crea un nuevo pedido.
+     *
+     * @param order persisted order / pedido persistido
+     */
+    public void publishOrderCreated(Order order) {
+        OrderEvent event = buildEvent(order, EVENT_ORDER_CREATED);
+        send(RabbitMQConfig.ORDER_CREATED_ROUTING_KEY, event);
+    }
+
+    /**
+     * Publish the event raised when an order is cancelled.
+     * Publica el evento generado cuando un pedido se cancela.
+     *
+     * @param order cancelled order / pedido cancelado
+     */
+    public void publishOrderCancelled(Order order) {
+        OrderEvent event = buildEvent(order, EVENT_ORDER_CANCELLED);
+        send(RabbitMQConfig.ORDER_CANCELLED_ROUTING_KEY, event);
+    }
+
+    private OrderEvent buildEvent(Order order, String eventType) {
+        return OrderEvent.builder()
+                .eventId(UUID.randomUUID().toString())
+                .eventType(eventType)
+                .orderId(order.getId())
+                .userId(order.getUserId())
+                .status(order.getStatus() != null ? order.getStatus().name() : null)
+                .totalAmount(order.getTotalAmount())
+                .occurredAt(LocalDateTime.now())
+                .build();
+    }
+
+    private void send(String routingKey, OrderEvent event) {
+        try {
+            rabbitTemplate.convertAndSend(RabbitMQConfig.ORDERS_EXCHANGE, routingKey, event);
+            log.info("Evento de pedido publicado. tipo={} routingKey={} orderId={}",
+                    event.getEventType(), routingKey, event.getOrderId());
+        } catch (AmqpException ex) {
+            log.error("Error publicando evento de pedido. tipo={} routingKey={} orderId={} causa={}",
+                    event.getEventType(), routingKey, event.getOrderId(), ex.getMessage());
+        }
+    }
+}

--- a/order-service/src/main/java/com/microcommerce/order/event/PaymentEvent.java
+++ b/order-service/src/main/java/com/microcommerce/order/event/PaymentEvent.java
@@ -1,0 +1,60 @@
+package com.microcommerce.order.event;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+/**
+ * Incoming payment event consumed by the Order Service.
+ * Evento de pago entrante consumido por el Order Service.
+ *
+ * Mirror of the payload published by the Payment Service.
+ * Refleja el payload publicado por el Payment Service.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class PaymentEvent implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    /** Unique event identifier. / Identificador unico del evento. */
+    private String eventId;
+
+    /** Event type (e.g. PAYMENT_COMPLETED, PAYMENT_FAILED). / Tipo de evento. */
+    private String eventType;
+
+    /** Payment identifier. / Identificador del pago. */
+    private Long paymentId;
+
+    /** Related order identifier. / Identificador de la orden relacionada. */
+    private String orderId;
+
+    /** User identifier. / Identificador del usuario. */
+    private Long userId;
+
+    /** Payment status. / Estado del pago. */
+    private String status;
+
+    /** Payment amount. / Monto del pago. */
+    private BigDecimal amount;
+
+    /** Currency code. / Codigo de moneda. */
+    private String currency;
+
+    /** Failure reason if the payment failed. / Motivo del fallo si el pago fallo. */
+    private String failureReason;
+
+    /** Event timestamp. / Marca temporal del evento. */
+    @JsonFormat(shape = JsonFormat.Shape.STRING)
+    private LocalDateTime occurredAt;
+}

--- a/order-service/src/main/java/com/microcommerce/order/event/PaymentEventListener.java
+++ b/order-service/src/main/java/com/microcommerce/order/event/PaymentEventListener.java
@@ -1,0 +1,75 @@
+package com.microcommerce.order.event;
+
+import com.microcommerce.order.config.RabbitMQConfig;
+import com.microcommerce.order.entity.Order.OrderStatus;
+import com.microcommerce.order.exception.InvalidOrderStatusException;
+import com.microcommerce.order.exception.OrderNotFoundException;
+import com.microcommerce.order.service.OrderService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Component;
+
+/**
+ * Listens for payment events published by the Payment Service and updates
+ * the related order accordingly.
+ * Escucha los eventos de pago publicados por el Payment Service y actualiza
+ * la orden relacionada en consecuencia.
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class PaymentEventListener {
+
+    public static final String EVENT_PAYMENT_COMPLETED = "PAYMENT_COMPLETED";
+    public static final String EVENT_PAYMENT_FAILED = "PAYMENT_FAILED";
+
+    private final OrderService orderService;
+
+    /**
+     * Handle incoming payment events.
+     * Manejar eventos de pago entrantes.
+     */
+    @RabbitListener(queues = RabbitMQConfig.ORDER_PAYMENT_EVENTS_QUEUE)
+    public void onPaymentEvent(PaymentEvent event) {
+        if (event == null || event.getEventType() == null) {
+            log.warn("Evento de pago recibido invalido, se descarta");
+            return;
+        }
+
+        log.info("Evento de pago recibido. tipo={} paymentId={} orderId={}",
+                event.getEventType(), event.getPaymentId(), event.getOrderId());
+
+        switch (event.getEventType()) {
+            case EVENT_PAYMENT_COMPLETED -> handlePaymentCompleted(event);
+            case EVENT_PAYMENT_FAILED -> handlePaymentFailed(event);
+            default -> log.debug("Tipo de evento de pago no manejado: {}", event.getEventType());
+        }
+    }
+
+    private void handlePaymentCompleted(PaymentEvent event) {
+        if (event.getOrderId() == null) {
+            log.warn("Evento PAYMENT_COMPLETED sin orderId, se descarta");
+            return;
+        }
+        try {
+            orderService.updateOrderStatus(event.getOrderId(), OrderStatus.PAID);
+            log.info("Pedido {} marcado como PAID tras evento de pago {}",
+                    event.getOrderId(), event.getEventId());
+        } catch (OrderNotFoundException ex) {
+            log.warn("Pedido {} no encontrado al procesar PAYMENT_COMPLETED", event.getOrderId());
+        } catch (InvalidOrderStatusException ex) {
+            log.warn("Transicion invalida al marcar pedido {} como PAID: {}",
+                    event.getOrderId(), ex.getMessage());
+        }
+    }
+
+    private void handlePaymentFailed(PaymentEvent event) {
+        if (event.getOrderId() == null) {
+            log.warn("Evento PAYMENT_FAILED sin orderId, se descarta");
+            return;
+        }
+        log.warn("Pago fallido recibido para pedido {}. Motivo: {}",
+                event.getOrderId(), event.getFailureReason());
+    }
+}

--- a/order-service/src/main/java/com/microcommerce/order/service/OrderServiceImpl.java
+++ b/order-service/src/main/java/com/microcommerce/order/service/OrderServiceImpl.java
@@ -3,6 +3,7 @@ package com.microcommerce.order.service;
 import com.microcommerce.order.dto.OrderDTO;
 import com.microcommerce.order.entity.Order;
 import com.microcommerce.order.entity.Order.OrderStatus;
+import com.microcommerce.order.event.OrderEventPublisher;
 import com.microcommerce.order.exception.EmptyOrderException;
 import com.microcommerce.order.exception.InvalidOrderStatusException;
 import com.microcommerce.order.exception.OrderNotFoundException;
@@ -31,6 +32,7 @@ public class OrderServiceImpl implements OrderService {
 
     private final OrderRepository orderRepository;
     private final OrderMapper orderMapper;
+    private final OrderEventPublisher orderEventPublisher;
 
     /**
      * Valid status transitions map.
@@ -70,6 +72,11 @@ public class OrderServiceImpl implements OrderService {
         Order savedOrder = orderRepository.save(order);
 
         log.info("Pedido creado satisfactoriamente con ID: {}", savedOrder.getId());
+
+        // Publish ORDER_CREATED event for downstream consumers
+        // Publicar evento ORDER_CREATED para consumidores downstream
+        orderEventPublisher.publishOrderCreated(savedOrder);
+
         return savedOrder;
     }
 
@@ -176,6 +183,13 @@ public class OrderServiceImpl implements OrderService {
         Order updatedOrder = orderRepository.save(order);
 
         log.info("Estado del pedido {} actualizado de {} a {}", id, currentStatus, newStatus);
+
+        // Publish ORDER_CANCELLED when the order is cancelled
+        // Publicar ORDER_CANCELLED cuando el pedido se cancela
+        if (newStatus == OrderStatus.CANCELLED) {
+            orderEventPublisher.publishOrderCancelled(updatedOrder);
+        }
+
         return updatedOrder;
     }
 

--- a/order-service/src/main/resources/application.yml
+++ b/order-service/src/main/resources/application.yml
@@ -15,6 +15,22 @@ spring:
       uri: mongodb://localhost:27017/orderdb
       auto-index-creation: true
 
+  # RabbitMQ Configuration
+  # Configuracion de RabbitMQ
+  rabbitmq:
+    host: ${RABBITMQ_HOST:localhost}
+    port: ${RABBITMQ_PORT:5672}
+    username: ${RABBITMQ_USER:guest}
+    password: ${RABBITMQ_PASSWORD:guest}
+    listener:
+      simple:
+        acknowledge-mode: auto
+        retry:
+          enabled: true
+          initial-interval: 1000
+          max-attempts: 3
+          multiplier: 2.0
+
   # Spring Cloud Config Client
   # Cliente de Spring Cloud Config
   cloud:

--- a/order-service/src/test/java/com/microcommerce/order/event/OrderEventPublisherTest.java
+++ b/order-service/src/test/java/com/microcommerce/order/event/OrderEventPublisherTest.java
@@ -1,0 +1,101 @@
+package com.microcommerce.order.event;
+
+import com.microcommerce.order.config.RabbitMQConfig;
+import com.microcommerce.order.entity.Order;
+import com.microcommerce.order.entity.Order.OrderStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.amqp.AmqpException;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Unit tests for OrderEventPublisher.
+ * Tests unitarios para OrderEventPublisher.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("OrderEventPublisher Tests")
+class OrderEventPublisherTest {
+
+    @Mock
+    private RabbitTemplate rabbitTemplate;
+
+    @InjectMocks
+    private OrderEventPublisher publisher;
+
+    private Order order;
+
+    @BeforeEach
+    void setUp() {
+        order = Order.builder()
+                .id("order-001")
+                .userId(1L)
+                .status(OrderStatus.PENDING)
+                .totalAmount(new BigDecimal("150.50"))
+                .build();
+    }
+
+    @Test
+    @DisplayName("publishOrderCreated - debe enviar evento al exchange con routing key correcta")
+    void publishOrderCreated_sendsEventWithCorrectRoutingKey() {
+        publisher.publishOrderCreated(order);
+
+        ArgumentCaptor<OrderEvent> captor = ArgumentCaptor.forClass(OrderEvent.class);
+        verify(rabbitTemplate).convertAndSend(
+                eq(RabbitMQConfig.ORDERS_EXCHANGE),
+                eq(RabbitMQConfig.ORDER_CREATED_ROUTING_KEY),
+                captor.capture());
+
+        OrderEvent event = captor.getValue();
+        assertThat(event.getEventType()).isEqualTo(OrderEventPublisher.EVENT_ORDER_CREATED);
+        assertThat(event.getOrderId()).isEqualTo("order-001");
+        assertThat(event.getUserId()).isEqualTo(1L);
+        assertThat(event.getStatus()).isEqualTo("PENDING");
+        assertThat(event.getTotalAmount()).isEqualByComparingTo(new BigDecimal("150.50"));
+        assertThat(event.getEventId()).isNotBlank();
+        assertThat(event.getOccurredAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("publishOrderCancelled - debe enviar evento con routing key de cancelacion")
+    void publishOrderCancelled_sendsCancelledEvent() {
+        order.setStatus(OrderStatus.CANCELLED);
+
+        publisher.publishOrderCancelled(order);
+
+        ArgumentCaptor<OrderEvent> captor = ArgumentCaptor.forClass(OrderEvent.class);
+        verify(rabbitTemplate).convertAndSend(
+                eq(RabbitMQConfig.ORDERS_EXCHANGE),
+                eq(RabbitMQConfig.ORDER_CANCELLED_ROUTING_KEY),
+                captor.capture());
+
+        assertThat(captor.getValue().getEventType()).isEqualTo(OrderEventPublisher.EVENT_ORDER_CANCELLED);
+        assertThat(captor.getValue().getStatus()).isEqualTo("CANCELLED");
+    }
+
+    @Test
+    @DisplayName("publishOrderCreated - debe capturar AmqpException sin propagarla")
+    void publishOrderCreated_swallowsAmqpException() {
+        doThrow(new AmqpException("broker down"))
+                .when(rabbitTemplate).convertAndSend(anyString(), anyString(), any(OrderEvent.class));
+
+        // No exception should propagate
+        publisher.publishOrderCreated(order);
+
+        verify(rabbitTemplate).convertAndSend(anyString(), anyString(), any(OrderEvent.class));
+    }
+}

--- a/order-service/src/test/java/com/microcommerce/order/event/PaymentEventListenerTest.java
+++ b/order-service/src/test/java/com/microcommerce/order/event/PaymentEventListenerTest.java
@@ -1,0 +1,118 @@
+package com.microcommerce.order.event;
+
+import com.microcommerce.order.entity.Order.OrderStatus;
+import com.microcommerce.order.exception.InvalidOrderStatusException;
+import com.microcommerce.order.exception.OrderNotFoundException;
+import com.microcommerce.order.service.OrderService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for PaymentEventListener.
+ * Tests unitarios para PaymentEventListener.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("PaymentEventListener Tests")
+class PaymentEventListenerTest {
+
+    @Mock
+    private OrderService orderService;
+
+    @InjectMocks
+    private PaymentEventListener listener;
+
+    @Test
+    @DisplayName("onPaymentEvent - PAYMENT_COMPLETED debe actualizar pedido a PAID")
+    void onPaymentEvent_paymentCompleted_updatesOrderToPaid() {
+        PaymentEvent event = PaymentEvent.builder()
+                .eventId("evt-1")
+                .eventType(PaymentEventListener.EVENT_PAYMENT_COMPLETED)
+                .orderId("order-001")
+                .paymentId(10L)
+                .build();
+        when(orderService.updateOrderStatus("order-001", OrderStatus.PAID)).thenReturn(null);
+
+        listener.onPaymentEvent(event);
+
+        verify(orderService).updateOrderStatus(eq("order-001"), eq(OrderStatus.PAID));
+    }
+
+    @Test
+    @DisplayName("onPaymentEvent - PAYMENT_FAILED no debe actualizar estado del pedido")
+    void onPaymentEvent_paymentFailed_doesNotUpdateStatus() {
+        PaymentEvent event = PaymentEvent.builder()
+                .eventId("evt-2")
+                .eventType(PaymentEventListener.EVENT_PAYMENT_FAILED)
+                .orderId("order-002")
+                .failureReason("Tarjeta rechazada")
+                .build();
+
+        listener.onPaymentEvent(event);
+
+        verify(orderService, never()).updateOrderStatus(eq("order-002"), eq(OrderStatus.PAID));
+    }
+
+    @Test
+    @DisplayName("onPaymentEvent - evento null debe ser descartado sin efectos")
+    void onPaymentEvent_nullEvent_isIgnored() {
+        listener.onPaymentEvent(null);
+
+        verifyNoInteractions(orderService);
+    }
+
+    @Test
+    @DisplayName("onPaymentEvent - tipo desconocido debe ser descartado")
+    void onPaymentEvent_unknownType_isIgnored() {
+        PaymentEvent event = PaymentEvent.builder()
+                .eventId("evt-3")
+                .eventType("UNKNOWN")
+                .orderId("order-003")
+                .build();
+
+        listener.onPaymentEvent(event);
+
+        verifyNoInteractions(orderService);
+    }
+
+    @Test
+    @DisplayName("onPaymentEvent - OrderNotFoundException se maneja silenciosamente")
+    void onPaymentEvent_orderNotFound_isHandled() {
+        PaymentEvent event = PaymentEvent.builder()
+                .eventId("evt-4")
+                .eventType(PaymentEventListener.EVENT_PAYMENT_COMPLETED)
+                .orderId("missing")
+                .build();
+        when(orderService.updateOrderStatus("missing", OrderStatus.PAID))
+                .thenThrow(new OrderNotFoundException("missing"));
+
+        listener.onPaymentEvent(event);
+
+        verify(orderService).updateOrderStatus(eq("missing"), eq(OrderStatus.PAID));
+    }
+
+    @Test
+    @DisplayName("onPaymentEvent - InvalidOrderStatusException se maneja silenciosamente")
+    void onPaymentEvent_invalidStatus_isHandled() {
+        PaymentEvent event = PaymentEvent.builder()
+                .eventId("evt-5")
+                .eventType(PaymentEventListener.EVENT_PAYMENT_COMPLETED)
+                .orderId("order-005")
+                .build();
+        when(orderService.updateOrderStatus("order-005", OrderStatus.PAID))
+                .thenThrow(new InvalidOrderStatusException(OrderStatus.CANCELLED, OrderStatus.PAID));
+
+        listener.onPaymentEvent(event);
+
+        verify(orderService).updateOrderStatus(eq("order-005"), eq(OrderStatus.PAID));
+    }
+}

--- a/order-service/src/test/java/com/microcommerce/order/service/OrderServiceImplTest.java
+++ b/order-service/src/test/java/com/microcommerce/order/service/OrderServiceImplTest.java
@@ -5,6 +5,7 @@ import com.microcommerce.order.dto.OrderItemDTO;
 import com.microcommerce.order.entity.Order;
 import com.microcommerce.order.entity.Order.OrderStatus;
 import com.microcommerce.order.entity.OrderItem;
+import com.microcommerce.order.event.OrderEventPublisher;
 import com.microcommerce.order.exception.EmptyOrderException;
 import com.microcommerce.order.exception.InvalidOrderStatusException;
 import com.microcommerce.order.exception.OrderNotFoundException;
@@ -42,6 +43,9 @@ class OrderServiceImplTest {
 
     @Mock
     private OrderMapper orderMapper;
+
+    @Mock
+    private OrderEventPublisher orderEventPublisher;
 
     @InjectMocks
     private OrderServiceImpl orderService;

--- a/payment-service/pom.xml
+++ b/payment-service/pom.xml
@@ -65,6 +65,12 @@
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
 
+        <!-- RabbitMQ for event-driven messaging -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-amqp</artifactId>
+        </dependency>
+
         <!-- Resilience4j Circuit Breaker -->
         <dependency>
             <groupId>io.github.resilience4j</groupId>
@@ -126,6 +132,13 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Spring AMQP test support -->
+        <dependency>
+            <groupId>org.springframework.amqp</groupId>
+            <artifactId>spring-rabbit-test</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/payment-service/src/main/java/com/microcommerce/payment/config/RabbitMQConfig.java
+++ b/payment-service/src/main/java/com/microcommerce/payment/config/RabbitMQConfig.java
@@ -1,0 +1,44 @@
+package com.microcommerce.payment.config;
+
+import org.springframework.amqp.core.TopicExchange;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * RabbitMQ configuration for the Payment Service.
+ * Configuracion de RabbitMQ para el Payment Service.
+ *
+ * Declares the payments topic exchange where payment events are published.
+ * Declara el topic exchange de pagos donde se publican los eventos de pago.
+ */
+@Configuration
+public class RabbitMQConfig {
+
+    public static final String PAYMENTS_EXCHANGE = "payments.exchange";
+
+    public static final String PAYMENT_COMPLETED_ROUTING_KEY = "payment.completed";
+    public static final String PAYMENT_FAILED_ROUTING_KEY = "payment.failed";
+    public static final String PAYMENT_REFUNDED_ROUTING_KEY = "payment.refunded";
+
+    @Bean
+    public TopicExchange paymentsExchange() {
+        return new TopicExchange(PAYMENTS_EXCHANGE, true, false);
+    }
+
+    @Bean
+    public MessageConverter jsonMessageConverter() {
+        return new Jackson2JsonMessageConverter();
+    }
+
+    @Bean
+    public RabbitTemplate rabbitTemplate(ConnectionFactory connectionFactory,
+                                         MessageConverter jsonMessageConverter) {
+        RabbitTemplate template = new RabbitTemplate(connectionFactory);
+        template.setMessageConverter(jsonMessageConverter);
+        return template;
+    }
+}

--- a/payment-service/src/main/java/com/microcommerce/payment/event/PaymentEvent.java
+++ b/payment-service/src/main/java/com/microcommerce/payment/event/PaymentEvent.java
@@ -1,0 +1,58 @@
+package com.microcommerce.payment.event;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+/**
+ * Event emitted by the Payment Service when a payment changes state.
+ * Evento emitido por el Payment Service cuando un pago cambia de estado.
+ *
+ * Serialized as JSON and routed through the payments exchange.
+ * Se serializa como JSON y se enruta a traves del exchange de pagos.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PaymentEvent implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    /** Unique event identifier. / Identificador unico del evento. */
+    private String eventId;
+
+    /** Event type (e.g. PAYMENT_COMPLETED, PAYMENT_FAILED). / Tipo de evento. */
+    private String eventType;
+
+    /** Payment identifier. / Identificador del pago. */
+    private Long paymentId;
+
+    /** Related order identifier. / Identificador de la orden relacionada. */
+    private String orderId;
+
+    /** User identifier. / Identificador del usuario. */
+    private Long userId;
+
+    /** Payment status. / Estado del pago. */
+    private String status;
+
+    /** Payment amount. / Monto del pago. */
+    private BigDecimal amount;
+
+    /** Currency code. / Codigo de moneda. */
+    private String currency;
+
+    /** Failure reason when the payment failed. / Motivo del fallo cuando el pago fallo. */
+    private String failureReason;
+
+    /** Event timestamp. / Marca temporal del evento. */
+    @JsonFormat(shape = JsonFormat.Shape.STRING)
+    private LocalDateTime occurredAt;
+}

--- a/payment-service/src/main/java/com/microcommerce/payment/event/PaymentEventPublisher.java
+++ b/payment-service/src/main/java/com/microcommerce/payment/event/PaymentEventPublisher.java
@@ -1,0 +1,81 @@
+package com.microcommerce.payment.event;
+
+import com.microcommerce.payment.config.RabbitMQConfig;
+import com.microcommerce.payment.entity.Payment;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.AmqpException;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * Publishes payment events to the payments exchange.
+ * Publica eventos de pago al exchange de pagos.
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class PaymentEventPublisher {
+
+    public static final String EVENT_PAYMENT_COMPLETED = "PAYMENT_COMPLETED";
+    public static final String EVENT_PAYMENT_FAILED = "PAYMENT_FAILED";
+    public static final String EVENT_PAYMENT_REFUNDED = "PAYMENT_REFUNDED";
+
+    private final RabbitTemplate rabbitTemplate;
+
+    /**
+     * Publish PAYMENT_COMPLETED event.
+     * Publicar evento PAYMENT_COMPLETED.
+     */
+    public void publishPaymentCompleted(Payment payment) {
+        PaymentEvent event = buildEvent(payment, EVENT_PAYMENT_COMPLETED);
+        send(RabbitMQConfig.PAYMENT_COMPLETED_ROUTING_KEY, event);
+    }
+
+    /**
+     * Publish PAYMENT_FAILED event.
+     * Publicar evento PAYMENT_FAILED.
+     */
+    public void publishPaymentFailed(Payment payment) {
+        PaymentEvent event = buildEvent(payment, EVENT_PAYMENT_FAILED);
+        send(RabbitMQConfig.PAYMENT_FAILED_ROUTING_KEY, event);
+    }
+
+    /**
+     * Publish PAYMENT_REFUNDED event.
+     * Publicar evento PAYMENT_REFUNDED.
+     */
+    public void publishPaymentRefunded(Payment payment) {
+        PaymentEvent event = buildEvent(payment, EVENT_PAYMENT_REFUNDED);
+        send(RabbitMQConfig.PAYMENT_REFUNDED_ROUTING_KEY, event);
+    }
+
+    private PaymentEvent buildEvent(Payment payment, String eventType) {
+        return PaymentEvent.builder()
+                .eventId(UUID.randomUUID().toString())
+                .eventType(eventType)
+                .paymentId(payment.getId())
+                .orderId(payment.getOrderId() != null ? String.valueOf(payment.getOrderId()) : null)
+                .userId(payment.getUserId())
+                .status(payment.getStatus() != null ? payment.getStatus().name() : null)
+                .amount(payment.getAmount())
+                .currency(payment.getCurrency())
+                .failureReason(payment.getFailureReason())
+                .occurredAt(LocalDateTime.now())
+                .build();
+    }
+
+    private void send(String routingKey, PaymentEvent event) {
+        try {
+            rabbitTemplate.convertAndSend(RabbitMQConfig.PAYMENTS_EXCHANGE, routingKey, event);
+            log.info("Evento de pago publicado. tipo={} routingKey={} paymentId={}",
+                    event.getEventType(), routingKey, event.getPaymentId());
+        } catch (AmqpException ex) {
+            log.error("Error publicando evento de pago. tipo={} routingKey={} paymentId={} causa={}",
+                    event.getEventType(), routingKey, event.getPaymentId(), ex.getMessage());
+        }
+    }
+}

--- a/payment-service/src/main/java/com/microcommerce/payment/service/PaymentServiceImpl.java
+++ b/payment-service/src/main/java/com/microcommerce/payment/service/PaymentServiceImpl.java
@@ -9,6 +9,7 @@ import com.microcommerce.payment.dto.response.StripePaymentIntentResponse;
 import com.microcommerce.payment.dto.response.StripeRefundResponse;
 import com.microcommerce.payment.entity.Payment;
 import com.microcommerce.payment.entity.PaymentStatus;
+import com.microcommerce.payment.event.PaymentEventPublisher;
 import com.microcommerce.payment.exception.InvalidPaymentStateException;
 import com.microcommerce.payment.exception.PaymentAlreadyProcessedException;
 import com.microcommerce.payment.exception.PaymentNotFoundException;
@@ -35,6 +36,7 @@ public class PaymentServiceImpl implements PaymentService {
     private final PaymentRepository paymentRepository;
     private final PaymentMapper paymentMapper;
     private final StripeClient stripeClient;
+    private final PaymentEventPublisher paymentEventPublisher;
 
     @Override
     public PaymentResponse processPayment(PaymentRequest request) {
@@ -97,6 +99,15 @@ public class PaymentServiceImpl implements PaymentService {
         }
 
         payment = paymentRepository.save(payment);
+
+        // Publish event based on final payment status
+        // Publicar evento segun el estado final del pago
+        if (payment.getStatus() == PaymentStatus.COMPLETED) {
+            paymentEventPublisher.publishPaymentCompleted(payment);
+        } else if (payment.getStatus() == PaymentStatus.FAILED) {
+            paymentEventPublisher.publishPaymentFailed(payment);
+        }
+
         return paymentMapper.toResponse(payment);
     }
 
@@ -188,6 +199,13 @@ public class PaymentServiceImpl implements PaymentService {
         }
 
         payment = paymentRepository.save(payment);
+
+        // Publish PAYMENT_REFUNDED event when refund completes successfully
+        // Publicar evento PAYMENT_REFUNDED cuando el reembolso se completa exitosamente
+        if (payment.getStatus() == PaymentStatus.REFUNDED) {
+            paymentEventPublisher.publishPaymentRefunded(payment);
+        }
+
         return paymentMapper.toResponse(payment);
     }
 

--- a/payment-service/src/main/resources/application.yml
+++ b/payment-service/src/main/resources/application.yml
@@ -24,6 +24,14 @@ spring:
         format_sql: true
         dialect: org.hibernate.dialect.PostgreSQLDialect
 
+  # RabbitMQ Configuration
+  # Configuracion de RabbitMQ
+  rabbitmq:
+    host: ${RABBITMQ_HOST:localhost}
+    port: ${RABBITMQ_PORT:5672}
+    username: ${RABBITMQ_USER:guest}
+    password: ${RABBITMQ_PASSWORD:guest}
+
 eureka:
   client:
     service-url:

--- a/payment-service/src/test/java/com/microcommerce/payment/event/PaymentEventPublisherTest.java
+++ b/payment-service/src/test/java/com/microcommerce/payment/event/PaymentEventPublisherTest.java
@@ -1,0 +1,121 @@
+package com.microcommerce.payment.event;
+
+import com.microcommerce.payment.config.RabbitMQConfig;
+import com.microcommerce.payment.entity.Payment;
+import com.microcommerce.payment.entity.PaymentMethod;
+import com.microcommerce.payment.entity.PaymentStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.amqp.AmqpException;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Unit tests for PaymentEventPublisher.
+ * Tests unitarios para PaymentEventPublisher.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("PaymentEventPublisher Tests")
+class PaymentEventPublisherTest {
+
+    @Mock
+    private RabbitTemplate rabbitTemplate;
+
+    @InjectMocks
+    private PaymentEventPublisher publisher;
+
+    private Payment payment;
+
+    @BeforeEach
+    void setUp() {
+        payment = Payment.builder()
+                .id(42L)
+                .orderId(100L)
+                .userId(7L)
+                .amount(new BigDecimal("25.00"))
+                .currency("USD")
+                .status(PaymentStatus.COMPLETED)
+                .paymentMethod(PaymentMethod.CREDIT_CARD)
+                .build();
+    }
+
+    @Test
+    @DisplayName("publishPaymentCompleted - debe publicar evento con routing key completed")
+    void publishPaymentCompleted_sendsCompletedEvent() {
+        publisher.publishPaymentCompleted(payment);
+
+        ArgumentCaptor<PaymentEvent> captor = ArgumentCaptor.forClass(PaymentEvent.class);
+        verify(rabbitTemplate).convertAndSend(
+                eq(RabbitMQConfig.PAYMENTS_EXCHANGE),
+                eq(RabbitMQConfig.PAYMENT_COMPLETED_ROUTING_KEY),
+                captor.capture());
+
+        PaymentEvent event = captor.getValue();
+        assertThat(event.getEventType()).isEqualTo(PaymentEventPublisher.EVENT_PAYMENT_COMPLETED);
+        assertThat(event.getPaymentId()).isEqualTo(42L);
+        assertThat(event.getOrderId()).isEqualTo("100");
+        assertThat(event.getUserId()).isEqualTo(7L);
+        assertThat(event.getStatus()).isEqualTo("COMPLETED");
+        assertThat(event.getAmount()).isEqualByComparingTo(new BigDecimal("25.00"));
+        assertThat(event.getCurrency()).isEqualTo("USD");
+        assertThat(event.getEventId()).isNotBlank();
+        assertThat(event.getOccurredAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("publishPaymentFailed - debe publicar evento con routing key failed")
+    void publishPaymentFailed_sendsFailedEvent() {
+        payment.setStatus(PaymentStatus.FAILED);
+        payment.setFailureReason("Tarjeta rechazada");
+
+        publisher.publishPaymentFailed(payment);
+
+        ArgumentCaptor<PaymentEvent> captor = ArgumentCaptor.forClass(PaymentEvent.class);
+        verify(rabbitTemplate).convertAndSend(
+                eq(RabbitMQConfig.PAYMENTS_EXCHANGE),
+                eq(RabbitMQConfig.PAYMENT_FAILED_ROUTING_KEY),
+                captor.capture());
+
+        PaymentEvent event = captor.getValue();
+        assertThat(event.getEventType()).isEqualTo(PaymentEventPublisher.EVENT_PAYMENT_FAILED);
+        assertThat(event.getFailureReason()).isEqualTo("Tarjeta rechazada");
+    }
+
+    @Test
+    @DisplayName("publishPaymentRefunded - debe publicar evento con routing key refunded")
+    void publishPaymentRefunded_sendsRefundedEvent() {
+        payment.setStatus(PaymentStatus.REFUNDED);
+
+        publisher.publishPaymentRefunded(payment);
+
+        verify(rabbitTemplate).convertAndSend(
+                eq(RabbitMQConfig.PAYMENTS_EXCHANGE),
+                eq(RabbitMQConfig.PAYMENT_REFUNDED_ROUTING_KEY),
+                any(PaymentEvent.class));
+    }
+
+    @Test
+    @DisplayName("publishPaymentCompleted - debe capturar AmqpException sin propagarla")
+    void publishPaymentCompleted_swallowsAmqpException() {
+        doThrow(new AmqpException("broker down"))
+                .when(rabbitTemplate).convertAndSend(anyString(), anyString(), any(PaymentEvent.class));
+
+        publisher.publishPaymentCompleted(payment);
+
+        verify(rabbitTemplate).convertAndSend(anyString(), anyString(), any(PaymentEvent.class));
+    }
+}

--- a/payment-service/src/test/java/com/microcommerce/payment/service/PaymentServiceImplTest.java
+++ b/payment-service/src/test/java/com/microcommerce/payment/service/PaymentServiceImplTest.java
@@ -9,6 +9,7 @@ import com.microcommerce.payment.dto.response.StripeRefundResponse;
 import com.microcommerce.payment.entity.Payment;
 import com.microcommerce.payment.entity.PaymentMethod;
 import com.microcommerce.payment.entity.PaymentStatus;
+import com.microcommerce.payment.event.PaymentEventPublisher;
 import com.microcommerce.payment.exception.InvalidPaymentStateException;
 import com.microcommerce.payment.exception.PaymentAlreadyProcessedException;
 import com.microcommerce.payment.exception.PaymentGatewayException;
@@ -52,6 +53,9 @@ class PaymentServiceImplTest {
 
     @Mock
     private StripeClient stripeClient;
+
+    @Mock
+    private PaymentEventPublisher paymentEventPublisher;
 
     @InjectMocks
     private PaymentServiceImpl paymentService;


### PR DESCRIPTION
## Summary

- Introduces RabbitMQ as the asynchronous backbone between Order Service and Payment Service.
- Order Service publishes `ORDER_CREATED` and `ORDER_CANCELLED`; Payment Service publishes `PAYMENT_COMPLETED`, `PAYMENT_FAILED`, `PAYMENT_REFUNDED`.
- Order Service consumes `payment.#` via a durable queue (with dead-letter) and transitions orders to `PAID` when a payment succeeds.
- Uses topic exchanges (`orders.exchange`, `payments.exchange`) with JSON serialization (Jackson2JsonMessageConverter).
- Adds RabbitMQ to `docker-compose-dev.yml` with the management UI on port 15672.
- Centralized config (`config/*.yml`), `.env.example` and README updated to document the new messaging infrastructure.

## Changes

- `order-service`:
  - `config/RabbitMQConfig` declares exchanges, payment-events queue, and DLQ/DLX bindings.
  - `event/OrderEvent`, `event/PaymentEvent`, `event/OrderEventPublisher`, `event/PaymentEventListener`.
  - `OrderServiceImpl` now publishes events on create/cancel.
  - Unit tests for the publisher and the listener (9 new tests).
- `payment-service`:
  - `config/RabbitMQConfig` declares the payments exchange.
  - `event/PaymentEvent`, `event/PaymentEventPublisher`.
  - `PaymentServiceImpl` publishes events on `processPayment` and `refundPayment`.
  - Unit tests for the publisher (4 new tests).
- Existing `OrderServiceImplTest` and `PaymentServiceImplTest` receive new `@Mock` for the publishers.

## Test plan

- [x] `mvn -pl order-service,payment-service -am compile` passes
- [x] `mvn -pl order-service,payment-service -am test-compile` passes
- [x] `OrderEventPublisherTest` (3/3) + `PaymentEventListenerTest` (6/6) green
- [x] `PaymentEventPublisherTest` (4/4) + `PaymentServiceImplTest` (26/26) green
- [x] `OrderServiceImplTest` regression: 33/34 pass (the single failure pre-existed in `develop` and is unrelated to this change)
- [x] Manual smoke test with RabbitMQ running (`docker-compose -f docker-compose-dev.yml up -d rabbitmq`) and both services started

## Notes

- Dead-letter queue `order.payment-events.dlq` catches payment events that are rejected by the consumer.
- RabbitMQ management UI available at http://localhost:15672 (default guest/guest).
- Events carry an `eventId` (UUID), `eventType`, relevant business IDs, status and timestamp for downstream correlation.