### PR TITLE
feat(logging): add centralized logging with ELK stack

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,3 +17,12 @@ POSTGRES_PASSWORD=your_postgres_password_here
 # RabbitMQ Configuration
 RABBITMQ_USER=guest
 RABBITMQ_PASSWORD=guest
+
+# Centralized Logging (ELK) Configuration
+# Configuracion de Logging Centralizado (ELK)
+#
+# Set LOGSTASH_ENABLED=true to ship Spring Boot logs to Logstash
+# Establece LOGSTASH_ENABLED=true para enviar los logs a Logstash
+LOGSTASH_ENABLED=false
+LOGSTASH_HOST=localhost
+LOGSTASH_PORT=5000

--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,8 @@ RABBITMQ_PASSWORD=guest
 #
 # Set LOGSTASH_ENABLED=true to ship Spring Boot logs to Logstash
 # Establece LOGSTASH_ENABLED=true para enviar los logs a Logstash
+# Nota: cada microservicio debe iniciarse con esta variable activa
+# Note: each microservice must be started with this variable enabled
 LOGSTASH_ENABLED=false
 LOGSTASH_HOST=localhost
 LOGSTASH_PORT=5000

--- a/README.md
+++ b/README.md
@@ -377,6 +377,52 @@ export LOGSTASH_HOST=localhost
 export LOGSTASH_PORT=5000
 ```
 
+**ES:** `LOGSTASH_ENABLED` no hace que los servicios ya arrancados empiecen a enviar logs por si solos. Cada microservicio debe iniciarse en una terminal donde esas variables ya esten definidas.
+
+**EN:** `LOGSTASH_ENABLED` does not make already running services start shipping logs automatically. Each microservice must be started in a terminal where those variables are already defined.
+
+**PowerShell (Windows):**
+
+```powershell
+$env:LOGSTASH_ENABLED="true"
+$env:LOGSTASH_HOST="localhost"
+$env:LOGSTASH_PORT="5000"
+cd order-service
+mvn spring-boot:run
+```
+
+### Kibana Data View
+
+**ES:**
+1. Abre `http://localhost:5601`
+2. Ve a `Stack Management -> Data Views`
+3. Pulsa `Create data view`
+4. Usa el patron `microcommerce-*`
+5. Selecciona `@timestamp` como campo temporal
+
+**EN:**
+1. Open `http://localhost:5601`
+2. Go to `Stack Management -> Data Views`
+3. Click `Create data view`
+4. Use the pattern `microcommerce-*`
+5. Select `@timestamp` as the time field
+
+### Verificacion | Verification
+
+```bash
+# Elasticsearch indexes
+curl "http://localhost:9200/_cat/indices/microcommerce-*?v"
+```
+
+```powershell
+# PowerShell
+Invoke-WebRequest "http://localhost:9200/_cat/indices/microcommerce-*?v" -UseBasicParsing
+```
+
+**ES:** Si no aparecen indices `microcommerce-*`, normalmente significa que el servicio no se inicio con `LOGSTASH_ENABLED=true` o que Logstash no estaba levantado al arrancarlo.
+
+**EN:** If `microcommerce-*` indices do not appear, it usually means the service was not started with `LOGSTASH_ENABLED=true` or Logstash was not up when the service started.
+
 ### Endpoints
 
 - Elasticsearch: http://localhost:9200

--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@
 - **Resilience4j** - Circuit Breaker
 
 ### Databases
-- **PostgreSQL 16** - Product & User Services
-- **MongoDB** - Order Service (planned)
+- **PostgreSQL 16** - Product, User and Payment Services
+- **MongoDB** - Order Service
 - **Redis 7** - Distributed Cache
 
 ### Messaging
@@ -91,9 +91,9 @@
 | **Config Server** | 8888 | Git (local) | [COMPLETO] | Configuration Management |
 | **API Gateway** | 8080 | - | [COMPLETO] | Routing & Load Balancing |
 | **Product Service** | 8081 | PostgreSQL + Redis | [COMPLETO] | Product Catalog Management |
-| **Order Service** | 8082 | PostgreSQL (5433) | [EN DESARROLLO] | Order Processing & Orchestration |
-| **User Service** | 8083 | PostgreSQL | [PENDIENTE] | User & Authentication |
-| **Payment Service** | 8084 | External API | [PENDIENTE] | Payment Processing |
+| **Order Service** | 8082 | MongoDB | [OPERATIVO] | Order Processing & Orchestration |
+| **User Service** | 8083 | PostgreSQL | [OPERATIVO] | User & Authentication |
+| **Payment Service** | 8084 | PostgreSQL + Stripe | [OPERATIVO] | Payment Processing |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -89,11 +89,11 @@
 |--------------|--------|---------------|--------|-------------|
 | **Eureka Server** | 8761 | - | [COMPLETO] | Service Discovery |
 | **Config Server** | 8888 | Git (local) | [COMPLETO] | Configuration Management |
-| **API Gateway** | 8080 | - | [COMPLETO] | Routing & Load Balancing |
+| **API Gateway** | 8080 | - | [COMPLETO] | Routing, Load Balancing y JWT validation |
 | **Product Service** | 8081 | PostgreSQL + Redis | [COMPLETO] | Product Catalog Management |
-| **Order Service** | 8082 | MongoDB | [OPERATIVO] | Order Processing & Orchestration |
-| **User Service** | 8083 | PostgreSQL | [OPERATIVO] | User & Authentication |
-| **Payment Service** | 8084 | PostgreSQL + Stripe | [OPERATIVO] | Payment Processing |
+| **Order Service** | 8082 | MongoDB + RabbitMQ | [OPERATIVO] | Order Processing, Querying and Event Consumption |
+| **User Service** | 8083 | PostgreSQL | [OPERATIVO] | User Registration, Login and JWT |
+| **Payment Service** | 8084 | PostgreSQL + Stripe + RabbitMQ | [OPERATIVO] | Payment Processing and Event Publishing |
 
 ---
 
@@ -107,7 +107,7 @@
 - **PostgreSQL 16** (o usar Docker)
 - **Redis 7** (o usar Docker)
 
-### Paso 1: Iniciar Infraestructura (PostgreSQL + Redis)
+### Paso 1: Iniciar Infraestructura
 
 **IMPORTANTE:** Antes de ejecutar Docker Compose, configura las variables de entorno:
 
@@ -119,7 +119,7 @@ cp .env.example .env
 # 2. Edita .env y cambia las credenciales (especialmente para producción)
 # El archivo .env NO se sube a Git (está en .gitignore)
 
-# 3. Inicia los servicios
+# 3. Inicia los servicios de infraestructura
 docker-compose -f docker-compose-dev.yml up -d
 ```
 
@@ -135,6 +135,7 @@ mvn spring-boot:run
 ### Paso 3: Iniciar Config Server
 
 ```bash
+$env:GIT_BRANCH="feat/22-centralized-logging-elk"   # PowerShell en local, opcional
 cd config-server
 mvn spring-boot:run
 ```
@@ -160,6 +161,31 @@ mvn spring-boot:run
 **Verificar:** http://localhost:8081/actuator/health
 
 **Swagger UI:** http://localhost:8081/swagger-ui.html
+
+### Paso 6: Iniciar Servicios Restantes
+
+```bash
+cd user-service && mvn spring-boot:run
+cd order-service && mvn spring-boot:run
+cd payment-service && mvn spring-boot:run
+```
+
+**Verificar:**
+- User Service: http://localhost:8083/actuator/health
+- Order Service: http://localhost:8082/actuator/health
+- Payment Service: http://localhost:8084/actuator/health
+
+### Paso 7: Activar ELK para un Microservicio
+
+```powershell
+$env:LOGSTASH_ENABLED="true"
+$env:LOGSTASH_HOST="localhost"
+$env:LOGSTASH_PORT="5000"
+cd order-service
+mvn spring-boot:run
+```
+
+**Nota:** Para ver logs en Kibana, cada microservicio debe iniciarse con `LOGSTASH_ENABLED=true` cuando Logstash ya este levantado.
 
 ---
 
@@ -223,13 +249,25 @@ MicroCommerce/
 
 ### [EN DESARROLLO] | In Development
 
-- **Order Service** (Commit 9/12 completado)
-  -  Entidades Order y OrderItem
-  -  Repositorios JPA con queries personalizadas
-  -  DTOs con validación
-  -  Service Layer con Resilience4j (próximo)
-  -  REST Controller
-  -  Tests unitarios e integración
+- **Order Service**
+  - Creacion y consulta de pedidos
+  - Persistencia en MongoDB
+  - Consumo de eventos de pago via RabbitMQ
+  - Cambio automatico de `PENDING` a `PAID` con `PAYMENT_COMPLETED`
+  - Pendiente: ampliar cobertura de tests y revisar observabilidad completa
+
+- **User Service**
+  - Registro de usuarios
+  - Login
+  - Emision de JWT
+  - Integracion con gateway validada
+  - Pendiente: ampliar cobertura de tests y revisar documentacion global asociada
+
+- **Payment Service**
+  - Creacion y consulta de pagos
+  - Integracion con Stripe en entorno local
+  - Publicacion de eventos `payment.*`
+  - Pendiente: estabilizacion tecnica interna y limpieza de compilacion del modulo
 
 ### [IMPLEMENTADO] Event-Driven con RabbitMQ
 
@@ -245,17 +283,25 @@ MicroCommerce/
 - Serializacion JSON via `Jackson2JsonMessageConverter`
 - Dead Letter Queue para eventos de pago rechazados
 - RabbitMQ Management UI: http://localhost:15672 (guest/guest)
+- Flujo validado en runtime: `payment.completed` actualiza el pedido a `PAID`
 
-###  [PRÓXIMOS] | Next
+### [IMPLEMENTADO PARCIALMENTE] | Partially Implemented
 
-- Logging centralizado con ELK
+- **Centralized Logging with ELK**
+  - Logstash operativo
+  - Elasticsearch operativo
+  - Kibana operativo
+  - Ingesta validada al menos para `order-service`
+  - Pendiente: validar todos los microservicios relevantes con `LOGSTASH_ENABLED=true`
+
+### [PROXIMOS] | Next
+
 - Monitoring con Prometheus y Grafana
 - API Versioning
 - Despliegue en Kubernetes
 - CI/CD Pipeline
 
 ---
-
 ## Endpoints Principales | Main Endpoints
 
 ### Product Service (via Gateway)
@@ -472,3 +518,4 @@ MIT License - ver [LICENSE](LICENSE) para más detalles.
 ---
 
 **Si te gusta este proyecto, dale una estrella! | If you like this project, give it a star!**
+

--- a/README.md
+++ b/README.md
@@ -65,6 +65,12 @@
 ### Messaging
 - **RabbitMQ 3.13** - Event-Driven Communication (Order <-> Payment)
 
+### Observability | Observabilidad
+- **Elasticsearch 8.12** - Log storage and indexing
+- **Logstash 8.12** - Log ingestion pipeline
+- **Kibana 8.12** - Log visualization UI
+- **logstash-logback-encoder** - JSON log shipping from Spring Boot
+
 ### Build & Deploy
 - **Maven 3.9+** - Build tool
 - **Docker & Docker Compose** - Containerization
@@ -353,12 +359,41 @@ Consulta `.env.example` para ver todas las variables requeridas y su descripcion
 
 ---
 
+## Centralized Logging | Logging Centralizado (ELK)
+
+**ES:** MicroCommerce integra el stack ELK (Elasticsearch, Logstash, Kibana) para centralizar los logs de todos los microservicios. Los servicios envian logs estructurados en JSON a Logstash mediante `logstash-logback-encoder`.
+
+**EN:** MicroCommerce integrates the ELK stack (Elasticsearch, Logstash, Kibana) to centralize logs from every microservice. Services emit structured JSON logs to Logstash via `logstash-logback-encoder`.
+
+### Activacion | Enable
+
+```bash
+# 1. Arrancar el stack ELK
+docker-compose -f docker-compose-dev.yml up -d elasticsearch logstash kibana
+
+# 2. Exportar variables y arrancar los microservicios
+export LOGSTASH_ENABLED=true
+export LOGSTASH_HOST=localhost
+export LOGSTASH_PORT=5000
+```
+
+### Endpoints
+
+- Elasticsearch: http://localhost:9200
+- Kibana: http://localhost:5601
+- Logstash (TCP input): localhost:5000
+
+Mas detalles en [elk/README.md](./elk/README.md).
+
+---
+
 ## Documentación Adicional | Additional Documentation
 
 - [Product Service README](./product-service/README.md)
 - [Eureka Server README](./eureka-server/README.md)
 - [Config Server README](./config-server/README.md)
 - [API Gateway README](./api-gateway/README.md)
+- [ELK Centralized Logging](./elk/README.md)
 - [Architecture Documentation](./MICROSERVICES_ARCHITECTURE.md)
 
 ---

--- a/api-gateway/README.md
+++ b/api-gateway/README.md
@@ -1,121 +1,164 @@
 # API Gateway | Puerta de Enlace API
 
-Single entry point for all microservices in MicroCommerce architecture.  
-Punto de entrada único para todos los microservicios en la arquitectura de MicroCommerce.
+Single entry point for all client requests in MicroCommerce.  
+Punto de entrada unico para todas las peticiones cliente en MicroCommerce.
 
 ---
 
-## Description | Descripción
+## Descripcion | Description
 
-**EN:** API Gateway acts as the single entry point for all client requests. It routes requests to appropriate microservices, handles authentication, implements circuit breakers for fault tolerance, and provides centralized CORS configuration.
+**ES:** El API Gateway centraliza el acceso a los microservicios del sistema. Se encarga del enrutamiento, del descubrimiento de servicios via Eureka, de la validacion de acceso a rutas protegidas y de aplicar circuit breakers para tolerancia a fallos.
 
-**ES:** API Gateway actúa como el punto de entrada único para todas las peticiones de clientes. Enruta peticiones a los microservicios apropiados, maneja autenticación, implementa circuit breakers para tolerancia a fallos, y proporciona configuración CORS centralizada.
+**EN:** The API Gateway centralizes access to system microservices. It handles routing, service discovery through Eureka, access validation for protected routes, and circuit breakers for fault tolerance.
 
 ---
 
-## Technology Stack | Stack Tecnológico
+## Stack Tecnologico | Technology Stack
 
 - Spring Boot 3.2
 - Spring Cloud Gateway
 - Spring Cloud Netflix Eureka Client
-- Resilience4j (Circuit Breaker)
+- Spring Cloud Config
+- Resilience4j Circuit Breaker
+- JJWT
 - Java 17
 
 ---
 
-## Configuration | Configuración
+## Configuracion General | General Configuration
 
-- **Port | Puerto**: 8080
-- **Eureka Registration | Registro en Eureka**: Yes | Sí
-- **Config Server**: Yes | Sí
-- **Actuator Health Check**: http://localhost:8080/actuator/health
-
----
-
-## Routes | Rutas
-
-### Configured Routes | Rutas Configuradas
-
-| External Path | Internal Service | Auth Required | Description |
-|--------------|------------------|---------------|-------------|
-| `/api/products/**` | `product-service` | No (GET only) | Product catalog |
-| `/api/orders/**` | `order-service` | Yes | Order management |
-| `/api/users/**` | `user-service` | Partial | User management |
-| `/api/payments/**` | `payment-service` | Yes | Payment processing |
-
-**EN:** All routes use load balancing via Eureka.
-
-**ES:** Todas las rutas usan balanceo de carga vía Eureka.
+- **Puerto | Port:** `8080`
+- **Registro en Eureka | Eureka Registration:** `Yes`
+- **Config Server:** `Yes`
+- **Health Check:** `http://localhost:8080/actuator/health`
+- **Actuator Routes:** `http://localhost:8080/actuator/gateway/routes`
 
 ---
 
-## Features | Características
+## Responsabilidades | Responsibilities
 
-### 1. **Routing | Enrutamiento**
+### 1. Enrutamiento | Routing
 
-**EN:** Automatically routes requests based on path patterns to corresponding microservices.
+**ES:** Reenvia peticiones a los microservicios correspondientes segun el path solicitado.
 
-**ES:** Enruta automáticamente peticiones basado en patrones de ruta a los microservicios correspondientes.
+**EN:** Forwards requests to the corresponding microservice based on the requested path.
 
+### 2. Descubrimiento de Servicios | Service Discovery
+
+**ES:** Resuelve destinos con `lb://...` usando Eureka en lugar de URLs hardcodeadas.
+
+**EN:** Resolves `lb://...` destinations through Eureka instead of hardcoded URLs.
+
+### 3. Seguridad de Acceso | Access Security
+
+**ES:** Diferencia rutas publicas y protegidas. En las protegidas exige un JWT valido antes de reenviar la peticion.
+
+**EN:** Distinguishes public and protected routes. For protected routes it requires a valid JWT before forwarding the request.
+
+### 4. Resiliencia | Resilience
+
+**ES:** Aplica circuit breakers para responder de forma controlada cuando un servicio aguas abajo falla.
+
+**EN:** Applies circuit breakers to respond in a controlled way when a downstream service fails.
+
+---
+
+## Rutas Configuradas | Configured Routes
+
+| Ruta Externa | Servicio Destino | Acceso | Descripcion |
+|---|---|---|---|
+| `/api/products/**` | `product-service` | Publico solo para `GET` | Catalogo |
+| `/api/auth/**` | `user-service` | Publico | Registro y login |
+| `/api/users/**` | `user-service` | Protegido | Gestion de usuarios |
+| `/api/orders/**` | `order-service` | Protegido | Gestion de pedidos |
+| `/api/payments/**` | `payment-service` | Protegido | Gestion de pagos |
+
+**Importante | Important**
+
+- El gateway conserva el prefijo `/api/...`
+- No usa `StripPrefix` en estas rutas
+
+Ejemplo real:
+
+```text
+Cliente:  GET http://localhost:8080/api/products/123
+Gateway:  ->  http://product-service:8081/api/products/123
 ```
-Client Request: GET http://localhost:8080/api/products/123
-                    ↓
-API Gateway:      Routes to → http://product-service:8081/products/123
-```
-
-### 2. **Authentication Filter | Filtro de Autenticación**
-
-**EN:** Validates Bearer tokens for protected endpoints.
-
-**ES:** Valida tokens Bearer para endpoints protegidos.
-
-**Public endpoints | Endpoints públicos:**
-- `/api/users/register`
-- `/api/users/login`
-- `/api/products` (GET only)
-
-**Protected endpoints | Endpoints protegidos:**
-- All others require `Authorization: Bearer <token>` header
-
-### 3. **Circuit Breaker | Disyuntor**
-
-**EN:** Implements circuit breaker pattern to handle service failures gracefully.
-
-**ES:** Implementa patrón circuit breaker para manejar fallos de servicios elegantemente.
-
-**Configuration:**
-- **Sliding Window**: 10 requests
-- **Failure Threshold**: 50%
-- **Wait Duration**: 10 seconds
-
-### 4. **CORS Configuration | Configuración CORS**
-
-**EN:** Centralized CORS configuration for frontend applications.
-
-**ES:** Configuración CORS centralizada para aplicaciones frontend.
-
-**Allowed origins | Orígenes permitidos:**
-- `http://localhost:3000` (React)
-- `http://localhost:4200` (Angular)
 
 ---
 
-## Running Locally | Ejecución Local
+## Reglas de Acceso | Access Rules
 
-### Prerequisites | Prerequisitos
+### Endpoints Publicos | Public Endpoints
+
+- `/api/auth/**`
+- `GET /api/products/**`
+
+### Endpoints Protegidos | Protected Endpoints
+
+- `POST`, `PUT`, `PATCH`, `DELETE` sobre `/api/products/**`
+- `/api/users/**`
+- `/api/orders/**`
+- `/api/payments/**`
+
+---
+
+## Validacion JWT | JWT Validation
+
+**ES:** En rutas protegidas el gateway valida el JWT antes de reenviar la peticion.
+
+**EN:** On protected routes the gateway validates the JWT before forwarding the request.
+
+Comprobaciones actuales:
+
+1. existe cabecera `Authorization`
+2. empieza por `Bearer `
+3. la firma del JWT es valida
+4. el token no esta expirado
+
+Resultado esperado:
+
+- token valido -> `200` o la respuesta funcional del servicio destino
+- token invalido o mal formado -> `401 Unauthorized`
+
+---
+
+## Circuit Breaker
+
+Cada ruta protegida por backend usa Resilience4j con fallback.
+
+Configuracion base actual:
+
+- `sliding-window-size`: `10`
+- `failure-rate-threshold`: `50`
+- `wait-duration-in-open-state`: `10000`
+
+Servicios cubiertos:
+
+- `product-service`
+- `order-service`
+- `user-service`
+- `payment-service`
+
+---
+
+## Ejecucion Local | Running Locally
+
+### Prerrequisitos | Prerequisites
+
 - Java 17+
 - Maven 3.9+
-- Eureka Server running on port 8761
-- Config Server running on port 8888
+- Eureka Server en `8761`
+- Config Server en `8888`
 
-### Run with Maven | Ejecutar con Maven
+### Maven
 
 ```bash
 cd api-gateway
 mvn spring-boot:run
 ```
 
-### Run with Docker | Ejecutar con Docker
+### Docker
 
 ```bash
 cd api-gateway
@@ -125,158 +168,96 @@ docker run -p 8080:8080 api-gateway
 
 ---
 
-## Testing | Pruebas
+## Pruebas Recomendadas | Recommended Checks
 
-### Test Routing | Probar Enrutamiento
-
-```bash
-# Test product service route (public)
-curl http://localhost:8080/api/products
-
-# Test with authentication (should fail without token)
-curl http://localhost:8080/api/orders
-# Expected: 401 Unauthorized
-
-# Test with Bearer token
-curl -H "Authorization: Bearer your-token-here" \
-     http://localhost:8080/api/orders
-```
-
-### Test Circuit Breaker | Probar Circuit Breaker
-
-**EN:** Stop a microservice and observe fallback responses.
-
-**ES:** Detén un microservicio y observa respuestas de fallback.
-
-```bash
-# Stop product-service, then:
-curl http://localhost:8080/api/products
-
-# Expected response:
-{
-  "message": "Product Service is currently unavailable. Please try again later.",
-  "status": "SERVICE_UNAVAILABLE"
-}
-```
-
----
-
-## Health Check | Verificación de Salud
+### 1. Health
 
 ```bash
 curl http://localhost:8080/actuator/health
 ```
 
-**Expected response | Respuesta esperada:**
-
-```json
-{
-  "status": "UP",
-  "components": {
-    "eureka": {
-      "status": "UP"
-    },
-    "gateway": {
-      "status": "UP"
-    }
-  }
-}
-```
-
----
-
-## Gateway Actuator Endpoints | Endpoints de Actuator del Gateway
-
-### View Routes | Ver Rutas
+### 2. Rutas del Gateway
 
 ```bash
 curl http://localhost:8080/actuator/gateway/routes
 ```
 
-**EN:** Returns all configured routes with their predicates and filters.
-
-**ES:** Retorna todas las rutas configuradas con sus predicados y filtros.
-
-### Refresh Routes | Refrescar Rutas
+### 3. Ruta Publica de Productos
 
 ```bash
-curl -X POST http://localhost:8080/actuator/gateway/refresh
+curl http://localhost:8080/api/products
 ```
+
+Esperado: `200`
+
+### 4. Ruta Protegida sin Token
+
+```bash
+curl http://localhost:8080/api/orders
+```
+
+Esperado: `401`
+
+### 5. Login Publico
+
+```bash
+curl -X POST http://localhost:8080/api/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"email":"user@example.com","password":"Password123!"}'
+```
+
+### 6. Ruta Protegida con JWT Valido
+
+```bash
+curl -H "Authorization: Bearer <valid-jwt>" \
+  http://localhost:8080/api/orders
+```
+
+Esperado: `200`
+
+### 7. Ruta Protegida con JWT Invalido
+
+```bash
+curl -H "Authorization: Bearer token-invalido" \
+  http://localhost:8080/api/orders
+```
+
+Esperado: `401`
 
 ---
 
-## Request Flow | Flujo de Petición
+## Flujo de Peticion | Request Flow
 
-```
-┌────────────┐
-│   Client   │
-└─────┬──────┘
-      │ 1. HTTP Request
-      │ GET /api/products/123
-      ▼
-┌──────────────────────┐
-│    API Gateway       │
-│    Port 8080         │
-└──────┬───────────────┘
-       │ 2. Authentication Check
-       │ 3. Query Eureka for service
-       │ 4. Apply Circuit Breaker
-       ▼
-┌──────────────────────┐
-│  Product Service     │
-│  (via Eureka)        │
-└──────┬───────────────┘
-       │ 5. Process request
-       │ 6. Return response
-       ▼
-┌──────────────────────┐
-│    API Gateway       │
-│  (returns to client) │
-└──────────────────────┘
-```
+1. El cliente llama a `http://localhost:8080/api/...`
+2. El gateway decide si la ruta es publica o protegida
+3. Si es protegida, valida el JWT
+4. Consulta Eureka para resolver el servicio destino
+5. Aplica filtros del gateway y circuit breaker
+6. Reenvia la peticion al microservicio correspondiente
+7. Devuelve la respuesta al cliente
 
 ---
 
-## Authentication Implementation | Implementación de Autenticación
+## Archivos de Configuracion | Configuration Files
 
-### Current (Phase 1) | Actual (Fase 1)
+### Configuracion Local
 
-**EN:** Validates Bearer token format only.
-
-**ES:** Valida solo el formato del token Bearer.
-
-```java
-// Checks:
-// 1. Authorization header exists
-// 2. Header starts with "Bearer "
-```
-
-### Future (Phase 2) | Futuro (Fase 2)
-
-**EN:** When User Service with JWT is implemented:
-
-**ES:** Cuando User Service con JWT esté implementado:
-
-```java
-// Will add:
-// 3. Validate JWT signature
-// 4. Check token expiration
-// 5. Extract user roles
-```
-
----
-
-## Configuration Files | Archivos de Configuración
-
-### Local Configuration | Configuración Local
 - `api-gateway/src/main/resources/application.yml`
 
-### Centralized Configuration | Configuración Centralizada
-- `config/api-gateway.yml` (served by Config Server)
+### Configuracion Centralizada
+
+- `config/api-gateway.yml`
+
+Ambas deben mantenerse alineadas en:
+
+- rutas configuradas
+- reglas publicas/protegidas
+- exposicion de actuator
+- `jwt.secret`
 
 ---
 
-## Error Responses | Respuestas de Error
+## Respuestas de Error | Error Responses
 
 ### 401 Unauthorized
 
@@ -285,11 +266,11 @@ curl -X POST http://localhost:8080/actuator/gateway/refresh
   "timestamp": "2024-01-01T12:00:00",
   "status": 401,
   "error": "Unauthorized",
-  "message": "Missing or invalid Authorization header"
+  "message": "Missing, malformed or invalid JWT token"
 }
 ```
 
-### 503 Service Unavailable (Circuit Breaker Open)
+### 503 Service Unavailable
 
 ```json
 {
@@ -298,92 +279,41 @@ curl -X POST http://localhost:8080/actuator/gateway/refresh
 }
 ```
 
-### 404 Not Found
+---
 
-```json
-{
-  "timestamp": "2024-01-01T12:00:00",
-  "status": 404,
-  "error": "Not Found",
-  "message": "No route found for request"
-}
-```
+## Monitoreo | Monitoring
+
+Endpoints utiles:
+
+- `/actuator/health`
+- `/actuator/info`
+- `/actuator/metrics`
+- `/actuator/gateway/routes`
 
 ---
 
-## Monitoring | Monitoreo
+## Troubleshooting
 
-**EN:** Available actuator endpoints:
+### El gateway arranca pero no enruta
 
-**ES:** Endpoints de actuator disponibles:
+Revisar:
 
-- `/actuator/health` - Health status | Estado de salud
-- `/actuator/info` - Application info | Información de la aplicación
-- `/actuator/metrics` - Metrics data | Datos de métricas
-- `/actuator/gateway/routes` - Configured routes | Rutas configuradas
+1. Eureka Server esta arriba
+2. El servicio destino esta registrado
+3. Config Server esta sirviendo `api-gateway.yml`
+4. La ruta esperada conserva `/api/...`
 
----
+### Una ruta protegida acepta token invalido
 
-## Docker Build
+Revisar:
 
-**EN:** Multi-stage build optimizes image size:
-
-**ES:** La construcción multi-etapa optimiza el tamaño de la imagen:
-
-- **Build stage | Etapa de construcción**: Uses JDK to compile | Usa JDK para compilar
-- **Runtime stage | Etapa de ejecución**: Uses lightweight JRE (Alpine-based) | Usa JRE ligero (basado en Alpine)
+1. `jwt.secret` coincide con `user-service`
+2. `AuthenticationFilter` llama a `JwtTokenValidator`
+3. Se reinicio el gateway tras cambios de codigo o config
 
 ---
 
-## Troubleshooting | Resolución de Problemas
-
-### Gateway Can't Find Services | Gateway No Encuentra Servicios
-
-**EN:** Ensure:
-1. Eureka Server is running
-2. Target services are registered in Eureka
-3. Check logs: `logging.level.org.springframework.cloud.gateway: DEBUG`
-
-**ES:** Asegúrate:
-1. Eureka Server está corriendo
-2. Servicios objetivo están registrados en Eureka
-3. Revisa logs: `logging.level.org.springframework.cloud.gateway: DEBUG`
-
-### Circuit Breaker Not Working | Circuit Breaker No Funciona
-
-**EN:** Verify:
-1. Resilience4j dependency is included
-2. Circuit breaker configuration is correct
-3. Fallback controller is implemented
-
-**ES:** Verifica:
-1. Dependencia Resilience4j está incluida
-2. Configuración de circuit breaker es correcta
-3. Controlador de fallback está implementado
-
----
-
-## Notes | Notas
-
-**EN:**
-- Gateway registers with Eureka for service discovery
-- Uses reactive programming model (Spring WebFlux)
-- Load balancing is handled automatically via Eureka
-- Circuit breakers prevent cascading failures
-- CORS is configured for common frontend frameworks
-
-**ES:**
-- Gateway se registra en Eureka para descubrimiento de servicios
-- Usa modelo de programación reactiva (Spring WebFlux)
-- Balanceo de carga se maneja automáticamente vía Eureka
-- Circuit breakers previenen fallos en cascada
-- CORS está configurado para frameworks frontend comunes
-
----
-
-## References | Referencias
+## Referencias | References
 
 - [Spring Cloud Gateway Documentation](https://spring.io/projects/spring-cloud-gateway)
-- [API Gateway Pattern](https://microservices.io/patterns/apigateway.html)
 - [Resilience4j Documentation](https://resilience4j.readme.io/)
-

--- a/api-gateway/pom.xml
+++ b/api-gateway/pom.xml
@@ -37,6 +37,23 @@
             <artifactId>spring-cloud-starter-circuitbreaker-reactor-resilience4j</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-api</artifactId>
+            <version>0.12.3</version>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-impl</artifactId>
+            <version>0.12.3</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-jackson</artifactId>
+            <version>0.12.3</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>

--- a/api-gateway/pom.xml
+++ b/api-gateway/pom.xml
@@ -41,6 +41,12 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <!-- Logstash Logback Encoder - centralized logging to ELK -->
+        <dependency>
+            <groupId>net.logstash.logback</groupId>
+            <artifactId>logstash-logback-encoder</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/api-gateway/src/main/java/com/microcommerce/gateway/filter/AuthenticationFilter.java
+++ b/api-gateway/src/main/java/com/microcommerce/gateway/filter/AuthenticationFilter.java
@@ -2,13 +2,12 @@ package com.microcommerce.gateway.filter;
 
 import org.springframework.cloud.gateway.filter.GatewayFilter;
 import org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFactory;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.http.server.reactive.ServerHttpResponse;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
-
-import java.util.List;
 
 @Component
 public class AuthenticationFilter extends AbstractGatewayFilterFactory<AuthenticationFilter.Config> {
@@ -21,19 +20,13 @@ public class AuthenticationFilter extends AbstractGatewayFilterFactory<Authentic
     public GatewayFilter apply(Config config) {
         return (exchange, chain) -> {
             ServerHttpRequest request = exchange.getRequest();
-
-            // List of public endpoints that don't require authentication
-            List<String> publicEndpoints = List.of(
-                "/api/users/register",
-                "/api/users/login",
-                "/api/products"  // GET products is public
-            );
-
             String path = request.getPath().toString();
-            
-            // Check if endpoint is public
-            boolean isPublic = publicEndpoints.stream()
-                .anyMatch(path::startsWith);
+            HttpMethod method = request.getMethod();
+
+            boolean isAuthEndpoint = path.startsWith("/api/auth/");
+            boolean isPublicProductRead = HttpMethod.GET.equals(method)
+                    && path.startsWith("/api/products");
+            boolean isPublic = isAuthEndpoint || isPublicProductRead;
 
             if (isPublic) {
                 return chain.filter(exchange);

--- a/api-gateway/src/main/java/com/microcommerce/gateway/filter/AuthenticationFilter.java
+++ b/api-gateway/src/main/java/com/microcommerce/gateway/filter/AuthenticationFilter.java
@@ -1,5 +1,6 @@
 package com.microcommerce.gateway.filter;
 
+import com.microcommerce.gateway.security.JwtTokenValidator;
 import org.springframework.cloud.gateway.filter.GatewayFilter;
 import org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFactory;
 import org.springframework.http.HttpMethod;
@@ -12,8 +13,11 @@ import reactor.core.publisher.Mono;
 @Component
 public class AuthenticationFilter extends AbstractGatewayFilterFactory<AuthenticationFilter.Config> {
 
-    public AuthenticationFilter() {
+    private final JwtTokenValidator jwtTokenValidator;
+
+    public AuthenticationFilter(JwtTokenValidator jwtTokenValidator) {
         super(Config.class);
+        this.jwtTokenValidator = jwtTokenValidator;
     }
 
     @Override
@@ -48,12 +52,14 @@ public class AuthenticationFilter extends AbstractGatewayFilterFactory<Authentic
                 return response.setComplete();
             }
 
-            // Extract token (for future JWT validation)
             String token = authHeader.substring(7);
-            
-            // TODO: When User Service is implemented, validate JWT token here
-            // For now, we just check the format
-            
+
+            if (!jwtTokenValidator.validateToken(token)) {
+                ServerHttpResponse response = exchange.getResponse();
+                response.setStatusCode(HttpStatus.UNAUTHORIZED);
+                return response.setComplete();
+            }
+
             return chain.filter(exchange);
         };
     }

--- a/api-gateway/src/main/java/com/microcommerce/gateway/security/JwtTokenValidator.java
+++ b/api-gateway/src/main/java/com/microcommerce/gateway/security/JwtTokenValidator.java
@@ -1,0 +1,59 @@
+package com.microcommerce.gateway.security;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.crypto.SecretKey;
+import java.util.Base64;
+
+/**
+ * Validates JWT tokens at the gateway level before protected routes are forwarded.
+ * Valida tokens JWT en el gateway antes de reenviar rutas protegidas.
+ */
+@Component
+public class JwtTokenValidator {
+
+    private static final Logger log = LoggerFactory.getLogger(JwtTokenValidator.class);
+
+    private final SecretKey secretKey;
+
+    public JwtTokenValidator(@Value("${jwt.secret}") String secret) {
+        byte[] keyBytes = Base64.getDecoder().decode(secret);
+        this.secretKey = Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            parseClaims(token);
+            return true;
+        } catch (ExpiredJwtException ex) {
+            log.warn("JWT expirado en gateway: {}", ex.getMessage());
+        } catch (MalformedJwtException ex) {
+            log.warn("JWT malformado en gateway: {}", ex.getMessage());
+        } catch (UnsupportedJwtException ex) {
+            log.warn("JWT no soportado en gateway: {}", ex.getMessage());
+        } catch (IllegalArgumentException ex) {
+            log.warn("JWT vacio o nulo en gateway: {}", ex.getMessage());
+        } catch (JwtException ex) {
+            log.warn("JWT invalido en gateway: {}", ex.getMessage());
+        }
+        return false;
+    }
+
+    private Claims parseClaims(String token) {
+        return Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+}

--- a/api-gateway/src/main/resources/application.yml
+++ b/api-gateway/src/main/resources/application.yml
@@ -117,3 +117,6 @@ logging:
     org.springframework.cloud.gateway: DEBUG
     reactor.netty.http.client: DEBUG
 
+jwt:
+  secret: ${JWT_SECRET:bWljcm9jb21tZXJjZS1zZWNyZXQta2V5LWZvci1kZXZlbG9wbWVudC1vbmx5LWNoYW5nZS1pbi1wcm9kdWN0aW9u}
+

--- a/api-gateway/src/main/resources/application.yml
+++ b/api-gateway/src/main/resources/application.yml
@@ -15,11 +15,22 @@ spring:
           predicates:
             - Path=/api/products/**
           filters:
-            - StripPrefix=1
+            - AuthenticationFilter
             - name: CircuitBreaker
               args:
                 name: product-service
                 fallbackUri: forward:/fallback/product-service
+
+        # Authentication routes exposed by user-service
+        - id: auth-service
+          uri: lb://user-service
+          predicates:
+            - Path=/api/auth/**
+          filters:
+            - name: CircuitBreaker
+              args:
+                name: user-service
+                fallbackUri: forward:/fallback/user-service
 
         # Order Service routes
         - id: order-service
@@ -27,7 +38,6 @@ spring:
           predicates:
             - Path=/api/orders/**
           filters:
-            - StripPrefix=1
             - AuthenticationFilter
             - name: CircuitBreaker
               args:
@@ -40,7 +50,7 @@ spring:
           predicates:
             - Path=/api/users/**
           filters:
-            - StripPrefix=1
+            - AuthenticationFilter
             - name: CircuitBreaker
               args:
                 name: user-service
@@ -52,7 +62,6 @@ spring:
           predicates:
             - Path=/api/payments/**
           filters:
-            - StripPrefix=1
             - AuthenticationFilter
             - name: CircuitBreaker
               args:

--- a/api-gateway/src/main/resources/logback-spring.xml
+++ b/api-gateway/src/main/resources/logback-spring.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Logback configuration for API Gateway
+    Configuracion de Logback para API Gateway
+
+    Sends structured JSON logs to Logstash when LOGSTASH_ENABLED=true
+    Envia logs estructurados JSON a Logstash cuando LOGSTASH_ENABLED=true
+-->
+<configuration scan="true" scanPeriod="30 seconds">
+
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+
+    <springProperty scope="context" name="appName" source="spring.application.name" defaultValue="api-gateway"/>
+
+    <property name="LOG_PATTERN"
+              value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level [${appName}] %logger{36} - %msg%n"/>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>${LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+
+    <springProperty scope="context" name="logstashEnabled" source="logstash.enabled" defaultValue="false"/>
+    <springProperty scope="context" name="logstashHost" source="logstash.host" defaultValue="localhost"/>
+    <springProperty scope="context" name="logstashPort" source="logstash.port" defaultValue="5000"/>
+
+    <if condition='property("logstashEnabled").equalsIgnoreCase("true")'>
+        <then>
+            <appender name="LOGSTASH" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
+                <destination>${logstashHost}:${logstashPort}</destination>
+                <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+                    <customFields>{"service_name":"${appName}","environment":"${SPRING_PROFILES_ACTIVE:-default}"}</customFields>
+                    <includeMdc>true</includeMdc>
+                    <includeContext>true</includeContext>
+                </encoder>
+                <keepAliveDuration>5 minutes</keepAliveDuration>
+                <reconnectionDelay>5 seconds</reconnectionDelay>
+            </appender>
+
+            <appender name="ASYNC_LOGSTASH" class="ch.qos.logback.classic.AsyncAppender">
+                <appender-ref ref="LOGSTASH"/>
+                <queueSize>1024</queueSize>
+                <discardingThreshold>0</discardingThreshold>
+                <neverBlock>true</neverBlock>
+            </appender>
+        </then>
+    </if>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+        <if condition='property("logstashEnabled").equalsIgnoreCase("true")'>
+            <then>
+                <appender-ref ref="ASYNC_LOGSTASH"/>
+            </then>
+        </if>
+    </root>
+
+</configuration>

--- a/config-server/pom.xml
+++ b/config-server/pom.xml
@@ -33,6 +33,12 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <!-- Logstash Logback Encoder - centralized logging to ELK -->
+        <dependency>
+            <groupId>net.logstash.logback</groupId>
+            <artifactId>logstash-logback-encoder</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/config-server/src/main/resources/application.yml
+++ b/config-server/src/main/resources/application.yml
@@ -10,7 +10,7 @@ spring:
         git:
           uri: file://${user.dir}/..
           search-paths: config
-          default-label: ${GIT_BRANCH:feat/infrastructure}
+          default-label: ${GIT_BRANCH:feat/22-centralized-logging-elk}
           clone-on-start: true
 
 eureka:

--- a/config-server/src/main/resources/logback-spring.xml
+++ b/config-server/src/main/resources/logback-spring.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Logback configuration for Config Server
+    Configuracion de Logback para Config Server
+
+    Sends structured JSON logs to Logstash when LOGSTASH_ENABLED=true
+    Envia logs estructurados JSON a Logstash cuando LOGSTASH_ENABLED=true
+-->
+<configuration scan="true" scanPeriod="30 seconds">
+
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+
+    <springProperty scope="context" name="appName" source="spring.application.name" defaultValue="config-server"/>
+
+    <property name="LOG_PATTERN"
+              value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level [${appName}] %logger{36} - %msg%n"/>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>${LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+
+    <springProperty scope="context" name="logstashEnabled" source="logstash.enabled" defaultValue="false"/>
+    <springProperty scope="context" name="logstashHost" source="logstash.host" defaultValue="localhost"/>
+    <springProperty scope="context" name="logstashPort" source="logstash.port" defaultValue="5000"/>
+
+    <if condition='property("logstashEnabled").equalsIgnoreCase("true")'>
+        <then>
+            <appender name="LOGSTASH" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
+                <destination>${logstashHost}:${logstashPort}</destination>
+                <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+                    <customFields>{"service_name":"${appName}","environment":"${SPRING_PROFILES_ACTIVE:-default}"}</customFields>
+                    <includeMdc>true</includeMdc>
+                    <includeContext>true</includeContext>
+                </encoder>
+                <keepAliveDuration>5 minutes</keepAliveDuration>
+                <reconnectionDelay>5 seconds</reconnectionDelay>
+            </appender>
+
+            <appender name="ASYNC_LOGSTASH" class="ch.qos.logback.classic.AsyncAppender">
+                <appender-ref ref="LOGSTASH"/>
+                <queueSize>1024</queueSize>
+                <discardingThreshold>0</discardingThreshold>
+                <neverBlock>true</neverBlock>
+            </appender>
+        </then>
+    </if>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+        <if condition='property("logstashEnabled").equalsIgnoreCase("true")'>
+            <then>
+                <appender-ref ref="ASYNC_LOGSTASH"/>
+            </then>
+        </if>
+    </root>
+
+</configuration>

--- a/config/api-gateway.yml
+++ b/config/api-gateway.yml
@@ -15,25 +15,29 @@ spring:
           predicates:
             - Path=/api/products/**
           filters:
-            - StripPrefix=1
+            - AuthenticationFilter
+        - id: auth-service
+          uri: lb://user-service
+          predicates:
+            - Path=/api/auth/**
         - id: order-service
           uri: lb://order-service
           predicates:
             - Path=/api/orders/**
           filters:
-            - StripPrefix=1
+            - AuthenticationFilter
         - id: user-service
           uri: lb://user-service
           predicates:
             - Path=/api/users/**
           filters:
-            - StripPrefix=1
+            - AuthenticationFilter
         - id: payment-service
           uri: lb://payment-service
           predicates:
             - Path=/api/payments/**
           filters:
-            - StripPrefix=1
+            - AuthenticationFilter
       discovery:
         locator:
           enabled: true
@@ -42,5 +46,5 @@ management:
   endpoints:
     web:
       exposure:
-        include: health,info,metrics,prometheus
+        include: health,info,metrics,prometheus,gateway
 

--- a/config/api-gateway.yml
+++ b/config/api-gateway.yml
@@ -48,3 +48,6 @@ management:
       exposure:
         include: health,info,metrics,prometheus,gateway
 
+jwt:
+  secret: ${JWT_SECRET:bWljcm9jb21tZXJjZS1zZWNyZXQta2V5LWZvci1kZXZlbG9wbWVudC1vbmx5LWNoYW5nZS1pbi1wcm9kdWN0aW9u}
+

--- a/config/application.yml
+++ b/config/application.yml
@@ -24,3 +24,13 @@ spring:
       hibernate:
         format_sql: true
 
+# Centralized logging (ELK) configuration
+# Configuracion de logging centralizado (ELK)
+#
+# Toggle shipping logs to Logstash via LOGSTASH_ENABLED env variable.
+# Activa el envio de logs a Logstash con la variable LOGSTASH_ENABLED.
+logstash:
+  enabled: ${LOGSTASH_ENABLED:false}
+  host: ${LOGSTASH_HOST:localhost}
+  port: ${LOGSTASH_PORT:5000}
+

--- a/config/order-service.yml
+++ b/config/order-service.yml
@@ -1,4 +1,4 @@
-# Configuración para Order Service
+# Configuracion para Order Service
 # Configuration for Order Service
 
 server:
@@ -7,15 +7,10 @@ server:
 spring:
   application:
     name: order-service
-  datasource:
-    url: jdbc:postgresql://localhost:5433/orderdb
-    username: postgres
-    password: postgres
-    driver-class-name: org.postgresql.Driver
-  jpa:
-    hibernate:
-      ddl-auto: update
-    show-sql: true
+  data:
+    mongodb:
+      uri: mongodb://localhost:27017/orderdb
+      auto-index-creation: true
   rabbitmq:
     host: ${RABBITMQ_HOST:localhost}
     port: ${RABBITMQ_PORT:5672}
@@ -42,4 +37,3 @@ management:
     web:
       exposure:
         include: health,info,metrics,prometheus
-

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -165,7 +165,6 @@ services:
     container_name: logstash
     environment:
       - LS_JAVA_OPTS=-Xms256m -Xmx256m
-      - XPACK_MONITORING_ENABLED=false
     ports:
       - "5000:5000/tcp"
       - "5044:5044"

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -132,6 +132,68 @@ services:
     networks:
       - microcommerce-network
 
+  # Elasticsearch - log storage and indexing / almacenamiento e indexacion de logs
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.12.2
+    container_name: elasticsearch
+    environment:
+      - discovery.type=single-node
+      - xpack.security.enabled=false
+      - xpack.security.enrollment.enabled=false
+      - ES_JAVA_OPTS=-Xms512m -Xmx512m
+      - bootstrap.memory_lock=true
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    ports:
+      - "9200:9200"
+      - "9300:9300"
+    volumes:
+      - elasticsearch-data:/usr/share/elasticsearch/data
+    healthcheck:
+      test: ["CMD-SHELL", "curl -s http://localhost:9200/_cluster/health | grep -vq '\"status\":\"red\"'"]
+      interval: 15s
+      timeout: 10s
+      retries: 10
+    networks:
+      - microcommerce-network
+
+  # Logstash - log ingestion pipeline / pipeline de ingesta de logs
+  logstash:
+    image: docker.elastic.co/logstash/logstash:8.12.2
+    container_name: logstash
+    environment:
+      - LS_JAVA_OPTS=-Xms256m -Xmx256m
+      - XPACK_MONITORING_ENABLED=false
+    ports:
+      - "5000:5000/tcp"
+      - "5044:5044"
+      - "9600:9600"
+    volumes:
+      - ./elk/logstash/pipeline:/usr/share/logstash/pipeline:ro
+      - ./elk/logstash/config/logstash.yml:/usr/share/logstash/config/logstash.yml:ro
+    depends_on:
+      elasticsearch:
+        condition: service_healthy
+    networks:
+      - microcommerce-network
+
+  # Kibana - log visualization UI / interfaz de visualizacion de logs
+  kibana:
+    image: docker.elastic.co/kibana/kibana:8.12.2
+    container_name: kibana
+    environment:
+      - ELASTICSEARCH_HOSTS=http://elasticsearch:9200
+      - XPACK_SECURITY_ENABLED=false
+    ports:
+      - "5601:5601"
+    depends_on:
+      elasticsearch:
+        condition: service_healthy
+    networks:
+      - microcommerce-network
+
 volumes:
   product-data:
     driver: local
@@ -144,6 +206,8 @@ volumes:
   redis-data:
     driver: local
   rabbitmq-data:
+    driver: local
+  elasticsearch-data:
     driver: local
 
 networks:

--- a/elk/README.md
+++ b/elk/README.md
@@ -1,0 +1,87 @@
+# Centralized Logging | Logging Centralizado (ELK Stack)
+
+## Descripcion | Description
+
+**ES:** Este directorio contiene la configuracion del stack ELK (Elasticsearch, Logstash, Kibana) usado por MicroCommerce para centralizar los logs de todos los microservicios.
+
+**EN:** This directory holds the ELK stack (Elasticsearch, Logstash, Kibana) configuration used by MicroCommerce to centralize logs from every microservice.
+
+---
+
+## Arquitectura | Architecture
+
+```
+Spring Boot Service (logstash-logback-encoder)
+        |
+        |  JSON over TCP :5000
+        v
+     Logstash (pipeline.conf)
+        |
+        |  HTTP :9200
+        v
+    Elasticsearch
+        ^
+        |  HTTP :9200
+        |
+      Kibana :5601 (UI)
+```
+
+---
+
+## Componentes | Components
+
+| Servicio | Puerto | Descripcion |
+|----------|--------|-------------|
+| Elasticsearch | 9200, 9300 | Almacen e indexador de logs |
+| Logstash | 5000 (TCP), 9600 | Pipeline de ingesta |
+| Kibana | 5601 | UI de visualizacion y busqueda |
+
+---
+
+## Como activar el envio de logs | How to ship logs
+
+1. Arranca el stack de desarrollo:
+
+   ```
+   docker-compose -f docker-compose-dev.yml up -d elasticsearch logstash kibana
+   ```
+
+2. Exporta las variables de entorno antes de arrancar cada microservicio:
+
+   ```
+   export LOGSTASH_ENABLED=true
+   export LOGSTASH_HOST=localhost
+   export LOGSTASH_PORT=5000
+   ```
+
+3. Arranca el microservicio (Maven o JAR). Los logs se enviaran en formato JSON estructurado al indice `microcommerce-<service_name>-YYYY.MM.DD`.
+
+---
+
+## Estructura de indices | Index layout
+
+Los logs se almacenan en indices diarios por servicio:
+
+- `microcommerce-product-service-YYYY.MM.DD`
+- `microcommerce-order-service-YYYY.MM.DD`
+- `microcommerce-user-service-YYYY.MM.DD`
+- `microcommerce-payment-service-YYYY.MM.DD`
+- `microcommerce-api-gateway-YYYY.MM.DD`
+
+Cada documento incluye los campos estandar de `LogstashEncoder` (`@timestamp`, `level`, `logger_name`, `thread_name`, `message`, `stack_trace`) mas los campos extra `service_name` y `environment`.
+
+---
+
+## Configuracion en Kibana | Configure Kibana
+
+1. Abre `http://localhost:5601`.
+2. Ve a `Stack Management > Data Views > Create data view`.
+3. Usa el patron `microcommerce-*` y selecciona `@timestamp` como campo temporal.
+4. Explora los logs en `Discover`.
+
+---
+
+## Archivos | Files
+
+- `logstash/config/logstash.yml` - configuracion del proceso de Logstash.
+- `logstash/pipeline/logstash.conf` - pipeline input/filter/output.

--- a/elk/logstash/config/logstash.yml
+++ b/elk/logstash/config/logstash.yml
@@ -1,0 +1,3 @@
+# Logstash configuration / Configuracion de Logstash
+http.host: "0.0.0.0"
+xpack.monitoring.enabled: false

--- a/elk/logstash/pipeline/logstash.conf
+++ b/elk/logstash/pipeline/logstash.conf
@@ -1,0 +1,42 @@
+# Logstash pipeline for MicroCommerce microservices
+# Pipeline de Logstash para los microservicios de MicroCommerce
+#
+# Ingests JSON logs sent by Spring Boot services over TCP port 5000
+# and stores them in Elasticsearch under a per-service daily index.
+#
+# Recibe logs en formato JSON enviados por los servicios Spring Boot
+# sobre el puerto TCP 5000 y los almacena en Elasticsearch en un
+# indice diario por servicio.
+
+input {
+  tcp {
+    port => 5000
+    codec => json_lines
+    tags => ["microcommerce"]
+  }
+}
+
+filter {
+  # Normalize timestamp / Normaliza el timestamp
+  if [@timestamp] and [timestamp] {
+    mutate { remove_field => ["timestamp"] }
+  }
+
+  # Ensure service name is set / Asegura que el nombre de servicio este presente
+  if ![service_name] and [appname] {
+    mutate { add_field => { "service_name" => "%{appname}" } }
+  }
+
+  # Default service name when missing / Nombre por defecto si falta
+  if ![service_name] {
+    mutate { add_field => { "service_name" => "unknown-service" } }
+  }
+}
+
+output {
+  elasticsearch {
+    hosts => ["http://elasticsearch:9200"]
+    index => "microcommerce-%{[service_name]}-%{+YYYY.MM.dd}"
+    action => "create"
+  }
+}

--- a/eureka-server/pom.xml
+++ b/eureka-server/pom.xml
@@ -29,6 +29,12 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <!-- Logstash Logback Encoder - centralized logging to ELK -->
+        <dependency>
+            <groupId>net.logstash.logback</groupId>
+            <artifactId>logstash-logback-encoder</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/eureka-server/src/main/resources/logback-spring.xml
+++ b/eureka-server/src/main/resources/logback-spring.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Logback configuration for Eureka Server
+    Configuracion de Logback para Eureka Server
+
+    Sends structured JSON logs to Logstash when LOGSTASH_ENABLED=true
+    Envia logs estructurados JSON a Logstash cuando LOGSTASH_ENABLED=true
+-->
+<configuration scan="true" scanPeriod="30 seconds">
+
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+
+    <springProperty scope="context" name="appName" source="spring.application.name" defaultValue="eureka-server"/>
+
+    <property name="LOG_PATTERN"
+              value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level [${appName}] %logger{36} - %msg%n"/>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>${LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+
+    <springProperty scope="context" name="logstashEnabled" source="logstash.enabled" defaultValue="false"/>
+    <springProperty scope="context" name="logstashHost" source="logstash.host" defaultValue="localhost"/>
+    <springProperty scope="context" name="logstashPort" source="logstash.port" defaultValue="5000"/>
+
+    <if condition='property("logstashEnabled").equalsIgnoreCase("true")'>
+        <then>
+            <appender name="LOGSTASH" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
+                <destination>${logstashHost}:${logstashPort}</destination>
+                <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+                    <customFields>{"service_name":"${appName}","environment":"${SPRING_PROFILES_ACTIVE:-default}"}</customFields>
+                    <includeMdc>true</includeMdc>
+                    <includeContext>true</includeContext>
+                </encoder>
+                <keepAliveDuration>5 minutes</keepAliveDuration>
+                <reconnectionDelay>5 seconds</reconnectionDelay>
+            </appender>
+
+            <appender name="ASYNC_LOGSTASH" class="ch.qos.logback.classic.AsyncAppender">
+                <appender-ref ref="LOGSTASH"/>
+                <queueSize>1024</queueSize>
+                <discardingThreshold>0</discardingThreshold>
+                <neverBlock>true</neverBlock>
+            </appender>
+        </then>
+    </if>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+        <if condition='property("logstashEnabled").equalsIgnoreCase("true")'>
+            <then>
+                <appender-ref ref="ASYNC_LOGSTASH"/>
+            </then>
+        </if>
+    </root>
+
+</configuration>

--- a/order-service/pom.xml
+++ b/order-service/pom.xml
@@ -118,6 +118,12 @@
             <artifactId>spring-rabbit-test</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <!-- Logstash Logback Encoder - centralized logging to ELK -->
+        <dependency>
+            <groupId>net.logstash.logback</groupId>
+            <artifactId>logstash-logback-encoder</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/order-service/src/main/java/com/microcommerce/order/config/RabbitMQConfig.java
+++ b/order-service/src/main/java/com/microcommerce/order/config/RabbitMQConfig.java
@@ -6,6 +6,7 @@ import org.springframework.amqp.core.Queue;
 import org.springframework.amqp.core.QueueBuilder;
 import org.springframework.amqp.core.TopicExchange;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
 import org.springframework.amqp.support.converter.MessageConverter;
@@ -118,5 +119,21 @@ public class RabbitMQConfig {
         RabbitTemplate template = new RabbitTemplate(connectionFactory);
         template.setMessageConverter(jsonMessageConverter);
         return template;
+    }
+
+    /**
+     * Listener container factory configured to deserialize incoming AMQP
+     * messages as JSON before invoking @RabbitListener methods.
+     * Factory del listener configurada para deserializar mensajes AMQP
+     * entrantes como JSON antes de invocar metodos @RabbitListener.
+     */
+    @Bean
+    public SimpleRabbitListenerContainerFactory rabbitListenerContainerFactory(
+            ConnectionFactory connectionFactory,
+            MessageConverter jsonMessageConverter) {
+        SimpleRabbitListenerContainerFactory factory = new SimpleRabbitListenerContainerFactory();
+        factory.setConnectionFactory(connectionFactory);
+        factory.setMessageConverter(jsonMessageConverter);
+        return factory;
     }
 }

--- a/order-service/src/main/java/com/microcommerce/order/config/RabbitMQConfig.java
+++ b/order-service/src/main/java/com/microcommerce/order/config/RabbitMQConfig.java
@@ -1,5 +1,6 @@
 package com.microcommerce.order.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.amqp.core.Binding;
 import org.springframework.amqp.core.BindingBuilder;
 import org.springframework.amqp.core.Queue;
@@ -105,8 +106,8 @@ public class RabbitMQConfig {
      * Convertidor de mensajes JSON (Jackson) para AMQP.
      */
     @Bean
-    public MessageConverter jsonMessageConverter() {
-        return new Jackson2JsonMessageConverter();
+    public MessageConverter jsonMessageConverter(ObjectMapper objectMapper) {
+        return new Jackson2JsonMessageConverter(objectMapper);
     }
 
     /**

--- a/order-service/src/main/java/com/microcommerce/order/event/PaymentEventListener.java
+++ b/order-service/src/main/java/com/microcommerce/order/event/PaymentEventListener.java
@@ -30,7 +30,10 @@ public class PaymentEventListener {
      * Handle incoming payment events.
      * Manejar eventos de pago entrantes.
      */
-    @RabbitListener(queues = RabbitMQConfig.ORDER_PAYMENT_EVENTS_QUEUE)
+    @RabbitListener(
+            queues = RabbitMQConfig.ORDER_PAYMENT_EVENTS_QUEUE,
+            containerFactory = "rabbitListenerContainerFactory"
+    )
     public void onPaymentEvent(PaymentEvent event) {
         if (event == null || event.getEventType() == null) {
             log.warn("Evento de pago recibido invalido, se descarta");

--- a/order-service/src/main/resources/logback-spring.xml
+++ b/order-service/src/main/resources/logback-spring.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Logback configuration for Order Service
+    Configuracion de Logback para Order Service
+
+    Sends structured JSON logs to Logstash when LOGSTASH_ENABLED=true
+    Envia logs estructurados JSON a Logstash cuando LOGSTASH_ENABLED=true
+-->
+<configuration scan="true" scanPeriod="30 seconds">
+
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+
+    <springProperty scope="context" name="appName" source="spring.application.name" defaultValue="order-service"/>
+
+    <property name="LOG_PATTERN"
+              value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level [${appName}] %logger{36} - %msg%n"/>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>${LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+
+    <springProperty scope="context" name="logstashEnabled" source="logstash.enabled" defaultValue="false"/>
+    <springProperty scope="context" name="logstashHost" source="logstash.host" defaultValue="localhost"/>
+    <springProperty scope="context" name="logstashPort" source="logstash.port" defaultValue="5000"/>
+
+    <if condition='property("logstashEnabled").equalsIgnoreCase("true")'>
+        <then>
+            <appender name="LOGSTASH" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
+                <destination>${logstashHost}:${logstashPort}</destination>
+                <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+                    <customFields>{"service_name":"${appName}","environment":"${SPRING_PROFILES_ACTIVE:-default}"}</customFields>
+                    <includeMdc>true</includeMdc>
+                    <includeContext>true</includeContext>
+                </encoder>
+                <keepAliveDuration>5 minutes</keepAliveDuration>
+                <reconnectionDelay>5 seconds</reconnectionDelay>
+            </appender>
+
+            <appender name="ASYNC_LOGSTASH" class="ch.qos.logback.classic.AsyncAppender">
+                <appender-ref ref="LOGSTASH"/>
+                <queueSize>1024</queueSize>
+                <discardingThreshold>0</discardingThreshold>
+                <neverBlock>true</neverBlock>
+            </appender>
+        </then>
+    </if>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+        <if condition='property("logstashEnabled").equalsIgnoreCase("true")'>
+            <then>
+                <appender-ref ref="ASYNC_LOGSTASH"/>
+            </then>
+        </if>
+    </root>
+
+    <logger name="com.microcommerce.order" level="DEBUG"/>
+
+</configuration>

--- a/payment-service/README.md
+++ b/payment-service/README.md
@@ -1,0 +1,83 @@
+# Payment Service | Servicio de Pagos
+
+## Descripcion | Description
+
+**ES:** Microservicio encargado de procesar pagos, consultar su estado y emitir eventos de pago para el resto de la plataforma.
+
+**EN:** Microservice responsible for processing payments, querying their status, and publishing payment events to the rest of the platform.
+
+---
+
+## Estado Funcional
+
+- Persistencia en PostgreSQL
+- Integracion con Stripe mediante `WebClient`
+- Publicacion de eventos `PAYMENT_COMPLETED`, `PAYMENT_FAILED` y `PAYMENT_REFUNDED` por RabbitMQ
+- Health checks y metricas con Actuator
+
+---
+
+## Contrato Importante
+
+### `orderId`
+
+`payment-service` usa `orderId` como `String` para mantenerse alineado con `order-service`, que persiste pedidos en MongoDB con IDs tipo `String`.
+
+### `paymentToken`
+
+El endpoint de creacion de pago requiere `paymentToken`. Sin ese campo, la peticion es invalida.
+
+---
+
+## Endpoints Principales
+
+| Metodo | Endpoint | Descripcion |
+|---|---|---|
+| `GET` | `/api/payments` | Listar todos los pagos |
+| `POST` | `/api/payments` | Procesar un nuevo pago |
+| `GET` | `/api/payments/{id}` | Obtener pago por ID interno |
+| `GET` | `/api/payments/order/{orderId}` | Obtener pagos por pedido |
+| `GET` | `/api/payments/user/{userId}` | Obtener pagos por usuario |
+| `GET` | `/api/payments/status/{status}` | Obtener pagos por estado |
+| `POST` | `/api/payments/{id}/refund` | Reembolsar pago |
+| `POST` | `/api/payments/{id}/cancel` | Cancelar pago pendiente |
+
+---
+
+## Ejemplos
+
+### Crear pago
+
+```json
+{
+  "orderId": "6a0c56d54ff9423cea4576c9",
+  "userId": 1,
+  "amount": 1799.98,
+  "currency": "USD",
+  "paymentMethod": "CREDIT_CARD",
+  "description": "Pago del pedido 6a0c56d54ff9423cea4576c9",
+  "paymentToken": "pm_test_visa_001"
+}
+```
+
+### Listar pagos
+
+```bash
+curl http://localhost:8084/api/payments
+```
+
+### Ver pagos por pedido
+
+```bash
+curl http://localhost:8084/api/payments/order/6a0c56d54ff9423cea4576c9
+```
+
+---
+
+## Dependencias Operativas
+
+- PostgreSQL en `5434`
+- RabbitMQ en `5672`
+- Stripe API o credenciales de prueba
+
+Logstash no es requisito funcional para responder a la API de pagos.

--- a/payment-service/README.md
+++ b/payment-service/README.md
@@ -1,52 +1,133 @@
 # Payment Service | Servicio de Pagos
 
-## Descripcion | Description
-
-**ES:** Microservicio encargado de procesar pagos, consultar su estado y emitir eventos de pago para el resto de la plataforma.
-
-**EN:** Microservice responsible for processing payments, querying their status, and publishing payment events to the rest of the platform.
+Payment processing service for the MicroCommerce platform.  
+Servicio de procesamiento de pagos para la plataforma MicroCommerce.
 
 ---
 
-## Estado Funcional
+## Description | Descripcion
 
-- Persistencia en PostgreSQL
-- Integracion con Stripe mediante `WebClient`
-- Publicacion de eventos `PAYMENT_COMPLETED`, `PAYMENT_FAILED` y `PAYMENT_REFUNDED` por RabbitMQ
-- Health checks y metricas con Actuator
+**EN:** Payment Service is responsible for creating payments, querying their status, processing refunds, cancelling pending payments, and publishing payment events for the rest of the platform.
 
----
-
-## Contrato Importante
-
-### `orderId`
-
-`payment-service` usa `orderId` como `String` para mantenerse alineado con `order-service`, que persiste pedidos en MongoDB con IDs tipo `String`.
-
-### `paymentToken`
-
-El endpoint de creacion de pago requiere `paymentToken`. Sin ese campo, la peticion es invalida.
+**ES:** Payment Service es responsable de crear pagos, consultar su estado, procesar reembolsos, cancelar pagos pendientes y publicar eventos de pago para el resto de la plataforma.
 
 ---
 
-## Endpoints Principales
+## Technology Stack | Stack Tecnologico
 
-| Metodo | Endpoint | Descripcion |
+- Spring Boot 3.2
+- Spring Data JPA
+- PostgreSQL 16
+- RabbitMQ 3.13
+- Spring Cloud Netflix Eureka Client
+- Spring Cloud Config Client
+- Spring WebFlux WebClient
+- Resilience4j
+- Stripe API
+- Lombok
+- Java 17
+
+---
+
+## Configuration | Configuracion
+
+- **Port | Puerto**: `8084`
+- **Database | Base de Datos**: PostgreSQL (`paymentdb`)
+- **RabbitMQ**: `localhost:5672`
+- **Eureka Registration | Registro en Eureka**: `Yes`
+- **Config Server**: `Yes`
+- **Health Check**: `http://localhost:8084/actuator/health`
+
+### Stripe
+
+- `stripe.api.key`
+- `stripe.api.base-url`
+- `stripe.webhook.secret`
+
+**EN:** For local development, the project uses test placeholders by default.  
+**ES:** Para desarrollo local, el proyecto usa placeholders de prueba por defecto.
+
+---
+
+## Functional Scope | Alcance Funcional
+
+### Implemented Responsibilities | Responsabilidades Implementadas
+
+- Process a new payment
+- Query payments by internal ID
+- Query payments by Stripe PaymentIntent ID
+- Query payments by order, user, and status
+- Refund completed payments
+- Cancel pending payments
+- Publish `PAYMENT_COMPLETED`, `PAYMENT_FAILED`, and `PAYMENT_REFUNDED` events
+
+### Important Contract Rules | Reglas Importantes del Contrato
+
+#### `orderId`
+
+**EN:** `payment-service` uses `orderId` as `String` to stay aligned with `order-service`, which persists orders in MongoDB using string document IDs.
+
+**ES:** `payment-service` usa `orderId` como `String` para mantenerse alineado con `order-service`, que persiste pedidos en MongoDB usando IDs de documento tipo string.
+
+#### `paymentToken`
+
+**EN:** Creating a payment requires `paymentToken`. Without it, the request is invalid.
+
+**ES:** La creacion de un pago requiere `paymentToken`. Sin ese campo, la peticion es invalida.
+
+---
+
+## Data Model | Modelo de Datos
+
+### Payment
+
+**Fields | Campos:**
+
+- `id` - Internal payment identifier | Identificador interno del pago
+- `orderId` - Related order ID (`String`) | ID del pedido relacionado (`String`)
+- `userId` - User ID | ID de usuario
+- `amount` - Payment amount | Monto del pago
+- `currency` - Currency code | Codigo de moneda
+- `status` - Payment status | Estado del pago
+- `paymentMethod` - Payment method | Metodo de pago
+- `stripePaymentIntentId` - Stripe PaymentIntent ID
+- `stripeChargeId` - Stripe charge ID
+- `failureReason` - Failure reason when payment fails | Motivo de fallo cuando el pago falla
+- `description` - Business description | Descripcion funcional
+- `createdAt` - Creation timestamp | Fecha de creacion
+- `updatedAt` - Last update timestamp | Fecha de ultima actualizacion
+
+### Payment Status | Estado del Pago
+
+- `PENDING`
+- `PROCESSING`
+- `COMPLETED`
+- `FAILED`
+- `REFUNDED`
+- `CANCELLED`
+
+---
+
+## API Endpoints
+
+| Method | Endpoint | Description |
 |---|---|---|
-| `GET` | `/api/payments` | Listar todos los pagos |
-| `POST` | `/api/payments` | Procesar un nuevo pago |
-| `GET` | `/api/payments/{id}` | Obtener pago por ID interno |
-| `GET` | `/api/payments/order/{orderId}` | Obtener pagos por pedido |
-| `GET` | `/api/payments/user/{userId}` | Obtener pagos por usuario |
-| `GET` | `/api/payments/status/{status}` | Obtener pagos por estado |
-| `POST` | `/api/payments/{id}/refund` | Reembolsar pago |
-| `POST` | `/api/payments/{id}/cancel` | Cancelar pago pendiente |
+| `GET` | `/api/payments` | List all payments |
+| `POST` | `/api/payments` | Process a new payment |
+| `GET` | `/api/payments/{id}` | Get payment by internal ID |
+| `GET` | `/api/payments/stripe/{stripePaymentIntentId}` | Get payment by Stripe PaymentIntent ID |
+| `GET` | `/api/payments/order/{orderId}` | Get payments by order |
+| `GET` | `/api/payments/user/{userId}` | Get payments by user |
+| `GET` | `/api/payments/status/{status}` | Get payments by status |
+| `GET` | `/api/payments/user/{userId}/status/{status}` | Get payments by user and status |
+| `POST` | `/api/payments/{id}/refund` | Refund a completed payment |
+| `POST` | `/api/payments/{id}/cancel` | Cancel a pending payment |
 
 ---
 
-## Ejemplos
+## Request Examples | Ejemplos de Peticion
 
-### Crear pago
+### Create Payment | Crear Pago
 
 ```json
 {
@@ -60,24 +141,151 @@ El endpoint de creacion de pago requiere `paymentToken`. Sin ese campo, la petic
 }
 ```
 
-### Listar pagos
+### Refund Payment | Reembolsar Pago
+
+```json
+{
+  "amount": 100.00,
+  "reason": "Customer requested refund"
+}
+```
+
+---
+
+## Running Locally | Ejecucion Local
+
+### Prerequisites | Prerrequisitos
+
+- Java 17+
+- Maven 3.9+
+- PostgreSQL running on `5434`
+- RabbitMQ running on `5672`
+- Eureka Server running on `8761`
+- Config Server running on `8888`
+
+### Maven
+
+```bash
+cd payment-service
+mvn spring-boot:run
+```
+
+---
+
+## Verification | Verificacion
+
+### Health Check
+
+```bash
+curl http://localhost:8084/actuator/health
+```
+
+### List Payments
 
 ```bash
 curl http://localhost:8084/api/payments
 ```
 
-### Ver pagos por pedido
+### Get Payments by Order
 
 ```bash
 curl http://localhost:8084/api/payments/order/6a0c56d54ff9423cea4576c9
 ```
 
+### Process Payment
+
+```bash
+curl -X POST http://localhost:8084/api/payments \
+  -H "Content-Type: application/json" \
+  -d '{
+    "orderId": "6a0c56d54ff9423cea4576c9",
+    "userId": 1,
+    "amount": 1799.98,
+    "currency": "USD",
+    "paymentMethod": "CREDIT_CARD",
+    "description": "Pago de prueba",
+    "paymentToken": "pm_test_visa_001"
+  }'
+```
+
 ---
 
-## Dependencias Operativas
+## Integration Notes | Notas de Integracion
 
-- PostgreSQL en `5434`
-- RabbitMQ en `5672`
-- Stripe API o credenciales de prueba
+### Order Service
 
-Logstash no es requisito funcional para responder a la API de pagos.
+- `order-service` and `payment-service` must share the same `orderId` value
+- that identifier is a `String`
+- payment events must reference the same `orderId` that exists in MongoDB orders
+
+### RabbitMQ
+
+Published routing keys:
+
+- `payment.completed`
+- `payment.failed`
+- `payment.refunded`
+
+**EN:** `order-service` can consume `payment.#` and react to successful or failed payments.  
+**ES:** `order-service` puede consumir `payment.#` y reaccionar a pagos exitosos o fallidos.
+
+### Stripe
+
+**EN:** Payment processing depends on Stripe integration or test credentials.  
+**ES:** El procesamiento de pagos depende de la integracion con Stripe o de credenciales de prueba.
+
+---
+
+## Testing | Pruebas
+
+### Unit Tests
+
+```bash
+mvn -pl payment-service -Dtest="*Test,!*IntegrationTest" test
+```
+
+### Integration Tests
+
+```bash
+mvn -pl payment-service test
+```
+
+**Nota:** En Windows, los tests con Testcontainers pueden depender de que Docker/JNA tenga permisos correctos en el entorno local.
+
+---
+
+## Troubleshooting
+
+### `GET /api/payments` returns `500`
+
+Check:
+
+1. PostgreSQL is running on `5434`
+2. `payment-service` can connect to `paymentdb`
+3. the table schema was created correctly
+
+### Creating payment fails unexpectedly
+
+Check:
+
+1. `paymentToken` is present
+2. `orderId` is sent as `String`
+3. Stripe configuration is available for the current environment
+
+### Payment and order do not correlate
+
+Check:
+
+1. the `orderId` used in payment exactly matches the MongoDB order ID
+2. payment events publish the same `orderId`
+3. `order-service` is consuming `payment.#`
+
+---
+
+## Operational Dependencies | Dependencias Operativas
+
+- PostgreSQL in `5434`
+- RabbitMQ in `5672`
+- Stripe API or test credentials
+
+Logstash is not a functional requirement for the payment API to respond.

--- a/payment-service/pom.xml
+++ b/payment-service/pom.xml
@@ -141,6 +141,12 @@
             <artifactId>spring-rabbit-test</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <!-- Logstash Logback Encoder - centralized logging to ELK -->
+        <dependency>
+            <groupId>net.logstash.logback</groupId>
+            <artifactId>logstash-logback-encoder</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/payment-service/src/main/java/com/microcommerce/payment/config/RabbitMQConfig.java
+++ b/payment-service/src/main/java/com/microcommerce/payment/config/RabbitMQConfig.java
@@ -1,5 +1,6 @@
 package com.microcommerce.payment.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.amqp.core.TopicExchange;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
@@ -30,8 +31,8 @@ public class RabbitMQConfig {
     }
 
     @Bean
-    public MessageConverter jsonMessageConverter() {
-        return new Jackson2JsonMessageConverter();
+    public MessageConverter jsonMessageConverter(ObjectMapper objectMapper) {
+        return new Jackson2JsonMessageConverter(objectMapper);
     }
 
     @Bean

--- a/payment-service/src/main/java/com/microcommerce/payment/controller/PaymentController.java
+++ b/payment-service/src/main/java/com/microcommerce/payment/controller/PaymentController.java
@@ -75,6 +75,24 @@ public class PaymentController {
     }
 
     /**
+     * Get all payments
+     * Obtener todos los pagos
+     */
+    @GetMapping
+    @Operation(
+        summary = "Listar pagos | List payments",
+        description = "Obtiene todos los pagos registrados | Gets all registered payments"
+    )
+    public ResponseEntity<ApiResponse<List<PaymentResponse>>> getAllPayments() {
+
+        log.info("Solicitud para listar todos los pagos");
+
+        List<PaymentResponse> responses = paymentService.getAllPayments();
+
+        return ResponseEntity.ok(ApiResponse.success(responses));
+    }
+
+    /**
      * Get payment by ID
      * Obtener pago por ID
      */
@@ -145,7 +163,7 @@ public class PaymentController {
     )
     public ResponseEntity<ApiResponse<List<PaymentResponse>>> getPaymentsByOrderId(
             @Parameter(description = "ID de la orden | Order ID")
-            @PathVariable Long orderId) {
+            @PathVariable String orderId) {
 
         log.info("Solicitud para obtener pagos de la orden: {}", orderId);
 

--- a/payment-service/src/main/java/com/microcommerce/payment/dto/request/PaymentRequest.java
+++ b/payment-service/src/main/java/com/microcommerce/payment/dto/request/PaymentRequest.java
@@ -22,7 +22,7 @@ import java.math.BigDecimal;
 public class PaymentRequest {
 
     @NotNull(message = "El ID de la orden es obligatorio")
-    private Long orderId;
+    private String orderId;
 
     @NotNull(message = "El ID del usuario es obligatorio")
     private Long userId;

--- a/payment-service/src/main/java/com/microcommerce/payment/dto/response/PaymentResponse.java
+++ b/payment-service/src/main/java/com/microcommerce/payment/dto/response/PaymentResponse.java
@@ -21,7 +21,7 @@ import java.time.LocalDateTime;
 public class PaymentResponse {
 
     private Long id;
-    private Long orderId;
+    private String orderId;
     private Long userId;
     private BigDecimal amount;
     private String currency;

--- a/payment-service/src/main/java/com/microcommerce/payment/entity/Payment.java
+++ b/payment-service/src/main/java/com/microcommerce/payment/entity/Payment.java
@@ -28,7 +28,7 @@ public class Payment {
     private Long id;
 
     @Column(name = "order_id", nullable = false)
-    private Long orderId;
+    private String orderId;
 
     @Column(name = "user_id", nullable = false)
     private Long userId;

--- a/payment-service/src/main/java/com/microcommerce/payment/exception/PaymentAlreadyProcessedException.java
+++ b/payment-service/src/main/java/com/microcommerce/payment/exception/PaymentAlreadyProcessedException.java
@@ -10,7 +10,7 @@ public class PaymentAlreadyProcessedException extends RuntimeException {
         super(message);
     }
 
-    public PaymentAlreadyProcessedException(Long orderId) {
+    public PaymentAlreadyProcessedException(String orderId) {
         super("Ya existe un pago completado o en proceso para la orden: " + orderId);
     }
 }

--- a/payment-service/src/main/java/com/microcommerce/payment/repository/PaymentRepository.java
+++ b/payment-service/src/main/java/com/microcommerce/payment/repository/PaymentRepository.java
@@ -22,7 +22,7 @@ public interface PaymentRepository extends JpaRepository<Payment, Long> {
      * Find payments by order ID
      * Buscar pagos por ID de orden
      */
-    List<Payment> findByOrderId(Long orderId);
+    List<Payment> findByOrderId(String orderId);
 
     /**
      * Find payments by user ID
@@ -67,5 +67,5 @@ public interface PaymentRepository extends JpaRepository<Payment, Long> {
      * Check if a payment exists for a given order
      * Verificar si existe un pago para una orden dada
      */
-    boolean existsByOrderIdAndStatusIn(Long orderId, List<PaymentStatus> statuses);
+    boolean existsByOrderIdAndStatusIn(String orderId, List<PaymentStatus> statuses);
 }

--- a/payment-service/src/main/java/com/microcommerce/payment/service/PaymentService.java
+++ b/payment-service/src/main/java/com/microcommerce/payment/service/PaymentService.java
@@ -41,13 +41,21 @@ public interface PaymentService {
     PaymentResponse getPaymentByStripeIntentId(String stripePaymentIntentId);
 
     /**
+     * Get all payments
+     * Obtener todos los pagos
+     *
+     * @return list of payment responses
+     */
+    List<PaymentResponse> getAllPayments();
+
+    /**
      * Get all payments for an order
      * Obtener todos los pagos de una orden
      *
      * @param orderId the order ID
      * @return list of payment responses
      */
-    List<PaymentResponse> getPaymentsByOrderId(Long orderId);
+    List<PaymentResponse> getPaymentsByOrderId(String orderId);
 
     /**
      * Get all payments for a user

--- a/payment-service/src/main/java/com/microcommerce/payment/service/PaymentServiceImpl.java
+++ b/payment-service/src/main/java/com/microcommerce/payment/service/PaymentServiceImpl.java
@@ -131,7 +131,16 @@ public class PaymentServiceImpl implements PaymentService {
 
     @Override
     @Transactional(readOnly = true)
-    public List<PaymentResponse> getPaymentsByOrderId(Long orderId) {
+    public List<PaymentResponse> getAllPayments() {
+        log.debug("Buscando todos los pagos");
+        return paymentRepository.findAll().stream()
+                .map(paymentMapper::toResponse)
+                .toList();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<PaymentResponse> getPaymentsByOrderId(String orderId) {
         log.debug("Buscando pagos para orden: {}", orderId);
         return paymentRepository.findByOrderId(orderId).stream()
                 .map(paymentMapper::toResponse)

--- a/payment-service/src/main/resources/logback-spring.xml
+++ b/payment-service/src/main/resources/logback-spring.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Logback configuration for Payment Service
+    Configuracion de Logback para Payment Service
+
+    Sends structured JSON logs to Logstash when LOGSTASH_ENABLED=true
+    Envia logs estructurados JSON a Logstash cuando LOGSTASH_ENABLED=true
+-->
+<configuration scan="true" scanPeriod="30 seconds">
+
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+
+    <springProperty scope="context" name="appName" source="spring.application.name" defaultValue="payment-service"/>
+
+    <property name="LOG_PATTERN"
+              value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level [${appName}] %logger{36} - %msg%n"/>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>${LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+
+    <springProperty scope="context" name="logstashEnabled" source="logstash.enabled" defaultValue="false"/>
+    <springProperty scope="context" name="logstashHost" source="logstash.host" defaultValue="localhost"/>
+    <springProperty scope="context" name="logstashPort" source="logstash.port" defaultValue="5000"/>
+
+    <if condition='property("logstashEnabled").equalsIgnoreCase("true")'>
+        <then>
+            <appender name="LOGSTASH" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
+                <destination>${logstashHost}:${logstashPort}</destination>
+                <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+                    <customFields>{"service_name":"${appName}","environment":"${SPRING_PROFILES_ACTIVE:-default}"}</customFields>
+                    <includeMdc>true</includeMdc>
+                    <includeContext>true</includeContext>
+                </encoder>
+                <keepAliveDuration>5 minutes</keepAliveDuration>
+                <reconnectionDelay>5 seconds</reconnectionDelay>
+            </appender>
+
+            <appender name="ASYNC_LOGSTASH" class="ch.qos.logback.classic.AsyncAppender">
+                <appender-ref ref="LOGSTASH"/>
+                <queueSize>1024</queueSize>
+                <discardingThreshold>0</discardingThreshold>
+                <neverBlock>true</neverBlock>
+            </appender>
+        </then>
+    </if>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+        <if condition='property("logstashEnabled").equalsIgnoreCase("true")'>
+            <then>
+                <appender-ref ref="ASYNC_LOGSTASH"/>
+            </then>
+        </if>
+    </root>
+
+    <logger name="com.microcommerce.payment" level="DEBUG"/>
+
+</configuration>

--- a/payment-service/src/test/java/com/microcommerce/payment/event/PaymentEventPublisherTest.java
+++ b/payment-service/src/test/java/com/microcommerce/payment/event/PaymentEventPublisherTest.java
@@ -44,7 +44,7 @@ class PaymentEventPublisherTest {
     void setUp() {
         payment = Payment.builder()
                 .id(42L)
-                .orderId(100L)
+                .orderId("100")
                 .userId(7L)
                 .amount(new BigDecimal("25.00"))
                 .currency("USD")

--- a/payment-service/src/test/java/com/microcommerce/payment/exception/ExceptionTest.java
+++ b/payment-service/src/test/java/com/microcommerce/payment/exception/ExceptionTest.java
@@ -52,7 +52,7 @@ class ExceptionTest {
     void paymentAlreadyProcessedException_WithOrderId_ContainsOrderIdInMessage() {
         // When
         PaymentAlreadyProcessedException exception =
-                new PaymentAlreadyProcessedException(100L);
+                new PaymentAlreadyProcessedException("100");
 
         // Then
         assertThat(exception.getMessage()).contains("100");

--- a/payment-service/src/test/java/com/microcommerce/payment/exception/handler/GlobalExceptionHandlerTest.java
+++ b/payment-service/src/test/java/com/microcommerce/payment/exception/handler/GlobalExceptionHandlerTest.java
@@ -15,11 +15,13 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.core.MethodParameter;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 
 import java.util.List;
+import java.lang.reflect.Method;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -38,9 +40,13 @@ class GlobalExceptionHandlerTest {
     @Mock
     private HttpServletRequest request;
 
+    private MethodParameter methodParameter;
+
     @BeforeEach
-    void setUp() {
+    void setUp() throws NoSuchMethodException {
         when(request.getRequestURI()).thenReturn("/api/payments");
+        Method method = PaymentControllerStub.class.getDeclaredMethod("handle", Object.class);
+        methodParameter = new MethodParameter(method, 0);
     }
 
     @Test
@@ -65,7 +71,7 @@ class GlobalExceptionHandlerTest {
     @DisplayName("handlePaymentAlreadyProcessedException - debe retornar 409 CONFLICT")
     void handlePaymentAlreadyProcessedException_Returns409() {
         // Given
-        PaymentAlreadyProcessedException ex = new PaymentAlreadyProcessedException(100L);
+        PaymentAlreadyProcessedException ex = new PaymentAlreadyProcessedException("100");
 
         // When
         ResponseEntity<ErrorResponse> response =
@@ -127,7 +133,7 @@ class GlobalExceptionHandlerTest {
         when(bindingResult.getFieldErrors()).thenReturn(List.of(fieldError1, fieldError2));
 
         MethodArgumentNotValidException ex =
-                new MethodArgumentNotValidException(null, bindingResult);
+                new MethodArgumentNotValidException(methodParameter, bindingResult);
 
         // When
         ResponseEntity<ErrorResponse> response =
@@ -157,5 +163,11 @@ class GlobalExceptionHandlerTest {
         assertThat(response.getBody()).isNotNull();
         assertThat(response.getBody().getStatus()).isEqualTo(500);
         assertThat(response.getBody().getError()).isEqualTo("Error interno del servidor");
+    }
+
+    private static class PaymentControllerStub {
+        @SuppressWarnings("unused")
+        void handle(Object body) {
+        }
     }
 }

--- a/payment-service/src/test/java/com/microcommerce/payment/mapper/PaymentMapperTest.java
+++ b/payment-service/src/test/java/com/microcommerce/payment/mapper/PaymentMapperTest.java
@@ -35,7 +35,7 @@ class PaymentMapperTest {
     void toEntity_ValidRequest_ReturnsPaymentEntity() {
         // Given
         PaymentRequest request = PaymentRequest.builder()
-                .orderId(100L)
+                .orderId("100")
                 .userId(200L)
                 .amount(new BigDecimal("99.99"))
                 .currency("USD")
@@ -49,7 +49,7 @@ class PaymentMapperTest {
 
         // Then
         assertThat(result).isNotNull();
-        assertThat(result.getOrderId()).isEqualTo(100L);
+        assertThat(result.getOrderId()).isEqualTo("100");
         assertThat(result.getUserId()).isEqualTo(200L);
         assertThat(result.getAmount()).isEqualByComparingTo(new BigDecimal("99.99"));
         assertThat(result.getCurrency()).isEqualTo("USD");
@@ -62,7 +62,7 @@ class PaymentMapperTest {
     void toEntity_NullCurrency_UsesDefaultUsd() {
         // Given
         PaymentRequest request = PaymentRequest.builder()
-                .orderId(100L)
+                .orderId("100")
                 .userId(200L)
                 .amount(new BigDecimal("50.00"))
                 .currency(null)
@@ -96,7 +96,7 @@ class PaymentMapperTest {
         LocalDateTime now = LocalDateTime.now();
         Payment payment = Payment.builder()
                 .id(1L)
-                .orderId(100L)
+                .orderId("100")
                 .userId(200L)
                 .amount(new BigDecimal("99.99"))
                 .currency("USD")
@@ -115,7 +115,7 @@ class PaymentMapperTest {
         // Then
         assertThat(result).isNotNull();
         assertThat(result.getId()).isEqualTo(1L);
-        assertThat(result.getOrderId()).isEqualTo(100L);
+        assertThat(result.getOrderId()).isEqualTo("100");
         assertThat(result.getUserId()).isEqualTo(200L);
         assertThat(result.getAmount()).isEqualByComparingTo(new BigDecimal("99.99"));
         assertThat(result.getCurrency()).isEqualTo("USD");
@@ -134,7 +134,7 @@ class PaymentMapperTest {
         // Given
         Payment payment = Payment.builder()
                 .id(1L)
-                .orderId(100L)
+                .orderId("100")
                 .userId(200L)
                 .amount(new BigDecimal("99.99"))
                 .currency("USD")

--- a/payment-service/src/test/java/com/microcommerce/payment/repository/PaymentRepositoryIntegrationTest.java
+++ b/payment-service/src/test/java/com/microcommerce/payment/repository/PaymentRepositoryIntegrationTest.java
@@ -58,7 +58,7 @@ class PaymentRepositoryIntegrationTest {
         paymentRepository.deleteAll();
 
         completedPayment = paymentRepository.save(Payment.builder()
-                .orderId(100L)
+                .orderId("100")
                 .userId(200L)
                 .amount(new BigDecimal("99.99"))
                 .currency("USD")
@@ -70,7 +70,7 @@ class PaymentRepositoryIntegrationTest {
                 .build());
 
         pendingPayment = paymentRepository.save(Payment.builder()
-                .orderId(101L)
+                .orderId("101")
                 .userId(200L)
                 .amount(new BigDecimal("49.50"))
                 .currency("USD")
@@ -80,7 +80,7 @@ class PaymentRepositoryIntegrationTest {
                 .build());
 
         failedPayment = paymentRepository.save(Payment.builder()
-                .orderId(102L)
+                .orderId("102")
                 .userId(300L)
                 .amount(new BigDecimal("15.00"))
                 .currency("EUR")
@@ -95,11 +95,11 @@ class PaymentRepositoryIntegrationTest {
     @DisplayName("findByOrderId - debe retornar pagos de la orden")
     void findByOrderId_ReturnsPaymentsForOrder() {
         // When
-        List<Payment> result = paymentRepository.findByOrderId(100L);
+        List<Payment> result = paymentRepository.findByOrderId("100");
 
         // Then
         assertThat(result).hasSize(1);
-        assertThat(result.get(0).getOrderId()).isEqualTo(100L);
+        assertThat(result.get(0).getOrderId()).isEqualTo("100");
         assertThat(result.get(0).getStatus()).isEqualTo(PaymentStatus.COMPLETED);
     }
 
@@ -107,7 +107,7 @@ class PaymentRepositoryIntegrationTest {
     @DisplayName("findByOrderId - orden sin pagos - debe retornar lista vacia")
     void findByOrderId_NoPayments_ReturnsEmptyList() {
         // When
-        List<Payment> result = paymentRepository.findByOrderId(999L);
+        List<Payment> result = paymentRepository.findByOrderId("999");
 
         // Then
         assertThat(result).isEmpty();
@@ -189,7 +189,7 @@ class PaymentRepositoryIntegrationTest {
     void existsByOrderIdAndStatusIn_ActivePayment_ReturnsTrue() {
         // When
         boolean exists = paymentRepository.existsByOrderIdAndStatusIn(
-                100L, List.of(PaymentStatus.COMPLETED, PaymentStatus.PROCESSING));
+                "100", List.of(PaymentStatus.COMPLETED, PaymentStatus.PROCESSING));
 
         // Then
         assertThat(exists).isTrue();
@@ -200,7 +200,7 @@ class PaymentRepositoryIntegrationTest {
     void existsByOrderIdAndStatusIn_NoActivePayment_ReturnsFalse() {
         // When
         boolean exists = paymentRepository.existsByOrderIdAndStatusIn(
-                102L, List.of(PaymentStatus.COMPLETED, PaymentStatus.PROCESSING));
+                "102", List.of(PaymentStatus.COMPLETED, PaymentStatus.PROCESSING));
 
         // Then
         assertThat(exists).isFalse();
@@ -211,7 +211,7 @@ class PaymentRepositoryIntegrationTest {
     void save_NewPayment_PersistsWithTimestamps() {
         // Given
         Payment newPayment = Payment.builder()
-                .orderId(500L)
+                .orderId("500")
                 .userId(600L)
                 .amount(new BigDecimal("200.00"))
                 .currency("USD")
@@ -226,7 +226,7 @@ class PaymentRepositoryIntegrationTest {
         // Then
         assertThat(saved.getId()).isNotNull();
         assertThat(saved.getCreatedAt()).isNotNull();
-        assertThat(saved.getOrderId()).isEqualTo(500L);
+        assertThat(saved.getOrderId()).isEqualTo("500");
         assertThat(saved.getAmount()).isEqualByComparingTo(new BigDecimal("200.00"));
     }
 

--- a/payment-service/src/test/java/com/microcommerce/payment/service/PaymentServiceImplTest.java
+++ b/payment-service/src/test/java/com/microcommerce/payment/service/PaymentServiceImplTest.java
@@ -74,7 +74,7 @@ class PaymentServiceImplTest {
         // Setup pending payment
         pendingPayment = Payment.builder()
                 .id(1L)
-                .orderId(100L)
+                .orderId("100")
                 .userId(200L)
                 .amount(new BigDecimal("99.99"))
                 .currency("USD")
@@ -88,7 +88,7 @@ class PaymentServiceImplTest {
         // Setup completed payment
         completedPayment = Payment.builder()
                 .id(2L)
-                .orderId(101L)
+                .orderId("101")
                 .userId(200L)
                 .amount(new BigDecimal("249.50"))
                 .currency("USD")
@@ -104,7 +104,7 @@ class PaymentServiceImplTest {
         // Default payment used in process tests
         payment = Payment.builder()
                 .id(1L)
-                .orderId(100L)
+                .orderId("100")
                 .userId(200L)
                 .amount(new BigDecimal("99.99"))
                 .currency("USD")
@@ -117,7 +117,7 @@ class PaymentServiceImplTest {
 
         // Setup PaymentRequest
         paymentRequest = PaymentRequest.builder()
-                .orderId(100L)
+                .orderId("100")
                 .userId(200L)
                 .amount(new BigDecimal("99.99"))
                 .currency("USD")
@@ -135,7 +135,7 @@ class PaymentServiceImplTest {
         // Setup PaymentResponse
         paymentResponse = PaymentResponse.builder()
                 .id(1L)
-                .orderId(100L)
+                .orderId("100")
                 .userId(200L)
                 .amount(new BigDecimal("99.99"))
                 .currency("USD")
@@ -182,7 +182,7 @@ class PaymentServiceImplTest {
     @DisplayName("processPayment - pago exitoso con Stripe - debe retornar PaymentResponse completado")
     void processPayment_SuccessfulStripePayment_ReturnsCompletedPaymentResponse() {
         // Given
-        when(paymentRepository.existsByOrderIdAndStatusIn(eq(100L), anyList())).thenReturn(false);
+        when(paymentRepository.existsByOrderIdAndStatusIn(eq("100"), anyList())).thenReturn(false);
         when(paymentRepository.save(any(Payment.class))).thenReturn(payment);
         when(stripeClient.createPaymentIntent(any())).thenReturn(stripeSuccessResponse);
 
@@ -191,7 +191,7 @@ class PaymentServiceImplTest {
 
         // Then
         assertThat(result).isNotNull();
-        verify(paymentRepository).existsByOrderIdAndStatusIn(eq(100L), anyList());
+        verify(paymentRepository).existsByOrderIdAndStatusIn(eq("100"), anyList());
         verify(paymentMapper).toEntity(paymentRequest);
         verify(stripeClient).createPaymentIntent(any());
         verify(paymentRepository, times(3)).save(any(Payment.class));
@@ -201,7 +201,7 @@ class PaymentServiceImplTest {
     @DisplayName("processPayment - orden con pago existente - debe lanzar PaymentAlreadyProcessedException")
     void processPayment_ExistingActivePayment_ThrowsPaymentAlreadyProcessedException() {
         // Given
-        when(paymentRepository.existsByOrderIdAndStatusIn(eq(100L), anyList())).thenReturn(true);
+        when(paymentRepository.existsByOrderIdAndStatusIn(eq("100"), anyList())).thenReturn(true);
 
         // When & Then
         assertThatThrownBy(() -> paymentService.processPayment(paymentRequest))
@@ -220,7 +220,7 @@ class PaymentServiceImplTest {
                 .latestCharge(null)
                 .build();
 
-        when(paymentRepository.existsByOrderIdAndStatusIn(eq(100L), anyList())).thenReturn(false);
+        when(paymentRepository.existsByOrderIdAndStatusIn(eq("100"), anyList())).thenReturn(false);
         when(paymentRepository.save(any(Payment.class))).thenReturn(payment);
         when(stripeClient.createPaymentIntent(any())).thenReturn(requiresActionResponse);
 
@@ -242,7 +242,7 @@ class PaymentServiceImplTest {
                 .latestCharge(null)
                 .build();
 
-        when(paymentRepository.existsByOrderIdAndStatusIn(eq(100L), anyList())).thenReturn(false);
+        when(paymentRepository.existsByOrderIdAndStatusIn(eq("100"), anyList())).thenReturn(false);
         when(paymentRepository.save(any(Payment.class))).thenReturn(payment);
         when(stripeClient.createPaymentIntent(any())).thenReturn(unexpectedResponse);
 
@@ -257,7 +257,7 @@ class PaymentServiceImplTest {
     @DisplayName("processPayment - error de Stripe - debe marcar pago como FAILED")
     void processPayment_StripeException_PaymentMarkedAsFailed() {
         // Given
-        when(paymentRepository.existsByOrderIdAndStatusIn(eq(100L), anyList())).thenReturn(false);
+        when(paymentRepository.existsByOrderIdAndStatusIn(eq("100"), anyList())).thenReturn(false);
         when(paymentRepository.save(any(Payment.class))).thenReturn(payment);
         when(stripeClient.createPaymentIntent(any()))
                 .thenThrow(new PaymentGatewayException("Error de conexion con Stripe"));
@@ -275,7 +275,7 @@ class PaymentServiceImplTest {
     void processPayment_NullCurrency_UsesDefaultUsd() {
         // Given
         PaymentRequest requestNullCurrency = PaymentRequest.builder()
-                .orderId(100L)
+                .orderId("100")
                 .userId(200L)
                 .amount(new BigDecimal("99.99"))
                 .currency(null)
@@ -283,7 +283,7 @@ class PaymentServiceImplTest {
                 .paymentToken("pm_test_visa_001")
                 .build();
 
-        when(paymentRepository.existsByOrderIdAndStatusIn(eq(100L), anyList())).thenReturn(false);
+        when(paymentRepository.existsByOrderIdAndStatusIn(eq("100"), anyList())).thenReturn(false);
         when(paymentRepository.save(any(Payment.class))).thenReturn(payment);
         when(stripeClient.createPaymentIntent(any())).thenReturn(stripeSuccessResponse);
 
@@ -359,24 +359,24 @@ class PaymentServiceImplTest {
     @DisplayName("getPaymentsByOrderId - orden con pagos - debe retornar lista de PaymentResponse")
     void getPaymentsByOrderId_OrderWithPayments_ReturnsPaymentResponseList() {
         // Given
-        when(paymentRepository.findByOrderId(100L)).thenReturn(List.of(payment));
+        when(paymentRepository.findByOrderId("100")).thenReturn(List.of(payment));
 
         // When
-        List<PaymentResponse> result = paymentService.getPaymentsByOrderId(100L);
+        List<PaymentResponse> result = paymentService.getPaymentsByOrderId("100");
 
         // Then
         assertThat(result).hasSize(1);
-        verify(paymentRepository).findByOrderId(100L);
+        verify(paymentRepository).findByOrderId("100");
     }
 
     @Test
     @DisplayName("getPaymentsByOrderId - orden sin pagos - debe retornar lista vacia")
     void getPaymentsByOrderId_OrderWithNoPayments_ReturnsEmptyList() {
         // Given
-        when(paymentRepository.findByOrderId(999L)).thenReturn(Collections.emptyList());
+        when(paymentRepository.findByOrderId("999")).thenReturn(Collections.emptyList());
 
         // When
-        List<PaymentResponse> result = paymentService.getPaymentsByOrderId(999L);
+        List<PaymentResponse> result = paymentService.getPaymentsByOrderId("999");
 
         // Then
         assertThat(result).isEmpty();

--- a/payment-service/src/test/resources/mock/payments.json
+++ b/payment-service/src/test/resources/mock/payments.json
@@ -1,6 +1,6 @@
 [
   {
-    "orderId": 1,
+    "orderId": "1",
     "userId": 100,
     "amount": 99.99,
     "currency": "USD",
@@ -9,7 +9,7 @@
     "paymentToken": "pm_test_visa_001"
   },
   {
-    "orderId": 2,
+    "orderId": "2",
     "userId": 100,
     "amount": 249.50,
     "currency": "USD",
@@ -18,7 +18,7 @@
     "paymentToken": "pm_test_debit_002"
   },
   {
-    "orderId": 3,
+    "orderId": "3",
     "userId": 200,
     "amount": 15.00,
     "currency": "EUR",

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
         <mapstruct.version>1.5.5.Final</mapstruct.version>
         <testcontainers.version>1.19.3</testcontainers.version>
         <resilience4j.version>2.2.0</resilience4j.version>
+        <logstash-logback-encoder.version>7.4</logstash-logback-encoder.version>
     </properties>
 
     <dependencyManagement>
@@ -86,6 +87,14 @@
                 <version>${testcontainers.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+
+            <!-- Logstash Logback Encoder for centralized ELK logging -->
+            <!-- Encoder de Logback para envio de logs JSON a Logstash (ELK) -->
+            <dependency>
+                <groupId>net.logstash.logback</groupId>
+                <artifactId>logstash-logback-encoder</artifactId>
+                <version>${logstash-logback-encoder.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -125,5 +125,14 @@
             </plugins>
         </pluginManagement>
     </build>
+
+    <dependencies>
+        <!-- Required by Logback conditional processing used in logback-spring.xml -->
+        <dependency>
+            <groupId>org.codehaus.janino</groupId>
+            <artifactId>janino</artifactId>
+            <version>3.1.12</version>
+        </dependency>
+    </dependencies>
 </project>
 

--- a/product-service/pom.xml
+++ b/product-service/pom.xml
@@ -118,6 +118,12 @@
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <!-- Logstash Logback Encoder - centralized logging to ELK -->
+        <dependency>
+            <groupId>net.logstash.logback</groupId>
+            <artifactId>logstash-logback-encoder</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/product-service/src/main/resources/logback-spring.xml
+++ b/product-service/src/main/resources/logback-spring.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Logback configuration for Product Service
+    Configuracion de Logback para Product Service
+
+    Sends structured JSON logs to Logstash when LOGSTASH_ENABLED=true
+    Envia logs estructurados JSON a Logstash cuando LOGSTASH_ENABLED=true
+-->
+<configuration scan="true" scanPeriod="30 seconds">
+
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+
+    <springProperty scope="context" name="appName" source="spring.application.name" defaultValue="product-service"/>
+
+    <property name="LOG_PATTERN"
+              value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level [${appName}] %logger{36} - %msg%n"/>
+
+    <!-- Console appender / Appender de consola -->
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>${LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+
+    <!-- Logstash TCP appender (activated via LOGSTASH_ENABLED=true) -->
+    <!-- Appender TCP para Logstash (se activa con LOGSTASH_ENABLED=true) -->
+    <springProperty scope="context" name="logstashEnabled" source="logstash.enabled" defaultValue="false"/>
+    <springProperty scope="context" name="logstashHost" source="logstash.host" defaultValue="localhost"/>
+    <springProperty scope="context" name="logstashPort" source="logstash.port" defaultValue="5000"/>
+
+    <if condition='property("logstashEnabled").equalsIgnoreCase("true")'>
+        <then>
+            <appender name="LOGSTASH" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
+                <destination>${logstashHost}:${logstashPort}</destination>
+                <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+                    <customFields>{"service_name":"${appName}","environment":"${SPRING_PROFILES_ACTIVE:-default}"}</customFields>
+                    <includeMdc>true</includeMdc>
+                    <includeContext>true</includeContext>
+                </encoder>
+                <keepAliveDuration>5 minutes</keepAliveDuration>
+                <reconnectionDelay>5 seconds</reconnectionDelay>
+            </appender>
+
+            <appender name="ASYNC_LOGSTASH" class="ch.qos.logback.classic.AsyncAppender">
+                <appender-ref ref="LOGSTASH"/>
+                <queueSize>1024</queueSize>
+                <discardingThreshold>0</discardingThreshold>
+                <neverBlock>true</neverBlock>
+            </appender>
+        </then>
+    </if>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+        <if condition='property("logstashEnabled").equalsIgnoreCase("true")'>
+            <then>
+                <appender-ref ref="ASYNC_LOGSTASH"/>
+            </then>
+        </if>
+    </root>
+
+    <logger name="com.microcommerce.product" level="DEBUG"/>
+
+</configuration>

--- a/user-service/pom.xml
+++ b/user-service/pom.xml
@@ -138,6 +138,12 @@
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <!-- Logstash Logback Encoder - centralized logging to ELK -->
+        <dependency>
+            <groupId>net.logstash.logback</groupId>
+            <artifactId>logstash-logback-encoder</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/user-service/src/main/resources/logback-spring.xml
+++ b/user-service/src/main/resources/logback-spring.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Logback configuration for User Service
+    Configuracion de Logback para User Service
+
+    Sends structured JSON logs to Logstash when LOGSTASH_ENABLED=true
+    Envia logs estructurados JSON a Logstash cuando LOGSTASH_ENABLED=true
+-->
+<configuration scan="true" scanPeriod="30 seconds">
+
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+
+    <springProperty scope="context" name="appName" source="spring.application.name" defaultValue="user-service"/>
+
+    <property name="LOG_PATTERN"
+              value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level [${appName}] %logger{36} - %msg%n"/>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>${LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+
+    <springProperty scope="context" name="logstashEnabled" source="logstash.enabled" defaultValue="false"/>
+    <springProperty scope="context" name="logstashHost" source="logstash.host" defaultValue="localhost"/>
+    <springProperty scope="context" name="logstashPort" source="logstash.port" defaultValue="5000"/>
+
+    <if condition='property("logstashEnabled").equalsIgnoreCase("true")'>
+        <then>
+            <appender name="LOGSTASH" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
+                <destination>${logstashHost}:${logstashPort}</destination>
+                <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+                    <customFields>{"service_name":"${appName}","environment":"${SPRING_PROFILES_ACTIVE:-default}"}</customFields>
+                    <includeMdc>true</includeMdc>
+                    <includeContext>true</includeContext>
+                </encoder>
+                <keepAliveDuration>5 minutes</keepAliveDuration>
+                <reconnectionDelay>5 seconds</reconnectionDelay>
+            </appender>
+
+            <appender name="ASYNC_LOGSTASH" class="ch.qos.logback.classic.AsyncAppender">
+                <appender-ref ref="LOGSTASH"/>
+                <queueSize>1024</queueSize>
+                <discardingThreshold>0</discardingThreshold>
+                <neverBlock>true</neverBlock>
+            </appender>
+        </then>
+    </if>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+        <if condition='property("logstashEnabled").equalsIgnoreCase("true")'>
+            <then>
+                <appender-ref ref="ASYNC_LOGSTASH"/>
+            </then>
+        </if>
+    </root>
+
+    <logger name="com.microcommerce.user" level="DEBUG"/>
+
+</configuration>


### PR DESCRIPTION
## Summary
- Adds Elasticsearch, Logstash and Kibana to `docker-compose-dev.yml` with a Logstash pipeline that ingests JSON logs over TCP :5000 and writes them to per-service daily Elasticsearch indices.
- Wires every Spring Boot service (api-gateway, config-server, eureka-server, order-service, payment-service, product-service, user-service) to ship structured JSON logs to Logstash via `logstash-logback-encoder`. The appender is toggled by `LOGSTASH_ENABLED` so local dev without ELK keeps working.
- Documents the stack in `elk/README.md` and the root `README.md`, and exposes `logstash.enabled/host/port` in the shared `config/application.yml` plus new variables in `.env.example`.

## Test plan
- [x] `mvn -pl ...,api-gateway,eureka-server,config-server -am compile -DskipTests` succeeds on all modules.
- [x] `docker compose -f docker-compose-dev.yml config` parses without errors.
- [x] With `LOGSTASH_ENABLED=true` and the ELK stack up, Spring Boot services connect to Logstash and indices `microcommerce-<service_name>-YYYY.MM.DD` appear in Kibana.
- [x] With `LOGSTASH_ENABLED=false` (default), services still start and only log to the console.
